### PR TITLE
atmosphere.glsl

### DIFF
--- a/data/shaders/atmosphere.glsl
+++ b/data/shaders/atmosphere.glsl
@@ -40,8 +40,638 @@ vec3 xyy_to_srgb(highp vec3 xyy)
     highp vec3 srgb = xyz_to_rgb * xyz;
     clamp(srgb, 0.0, 1.0);
     return srgb;
+} <qresource prefix="/">	    <qresource prefix="/">
+        <file>shaders/xyYToRGB.glsl</file>	        <file>shaders/xyYToRGB.glsl</file>
+    </qresource>	    </qresource>
+    <qresource prefix="/">
+        <file>shaders/xyYToRGB.frag</file>
+    </qresource>
+    <qresource prefix="/">
+        <file>shaders/AtmosphereFunctions.frag</file>
+    </qresource>
+    <qresource prefix="/">
+        <file>shaders/AtmosphereMain.vert</file>
+    </qresource>
+    <qresource prefix="/">
+        <file>shaders/AtmosphereMain.frag</file>
+    </qresource>
+</RCC>	</RCC>
+#version 130
+
+const float kLengthUnitInMeters = 1000.000000;
+const float earthRadius=6.36e6/kLengthUnitInMeters;
+const float sunAngularRadius=0.00935/2;
+
+const vec2 sun_size=vec2(tan(sunAngularRadius),cos(sunAngularRadius));
+const vec3 earth_center=vec3(0,0,-earthRadius);
+const float exposure=0.6;
+
+uniform vec3 camera;
+uniform vec3 sun_direction;
+
+in vec3 view_ray;
+out vec4 color;
+vec3 GetSolarLuminance();
+vec3 GetSkyLuminance(vec3 camera, vec3 view_ray, float shadow_length,
+                     vec3 sun_direction, out vec3 transmittance);
+vec3 adaptColorToVisionMode(vec3 rgb);
+vec3 dither(vec3);
+void main()
+{
+    vec3 view_direction=normalize(view_ray);
+    float fragment_angular_size = length(dFdx(view_direction) + dFdy(view_direction));
+    vec3 transmittance;
+    vec3 radiance = GetSkyLuminance(camera - earth_center, view_direction, 0, sun_direction, transmittance);
+    /*
+    // This 'if' case is useful when we want to check that the Sun is where
+    // it's supposed to be and, ideally, has the color it's supposed to have
+    if (dot(view_direction, sun_direction) > sun_size.y)
+        radiance += transmittance * GetSolarLuminance();
+     */
+    color = vec4(dither(pow(adaptColorToVisionMode(radiance * exposure), vec3(1.0 / 2.2))),1);
+}uniform mediump mat4 projectionMatrix;
+
+attribute vec2 vertex;
+attribute vec3 viewRay;
+
+varying vec3 view_ray;
+
+void main()
+{* Stellarium
+ * Copyright (C) 2002-2018 Fabien Chereau and Stellarium contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */
+
+#version 130
+
+const highp float pi = 3.1415926535897931;
+const highp float ln10 = 2.3025850929940459;
+
+// Variable for the xyYTo RGB conversion
+uniform highp float alphaWaOverAlphaDa;
+uniform highp float oneOverGamma;
+uniform highp float term2TimesOneOverMaxdLpOneOverGamma;
+uniform highp float brightnessScale;
+
+vec3 XYZ2xyY(vec3 XYZ)
+{
+	return vec3(XYZ.xy/(XYZ.x+XYZ.y+XYZ.z), XYZ.y);
 }
 
+vec3 RGB2XYZ(vec3 rgb)
+{
+	return rgb*mat3(0.4124564, 0.3575761, 0.1804375,
+					0.2126729, 0.7151522, 0.0721750,
+					0.0193339, 0.1191920, 0.9503041);
+}
+
+vec3 adaptColorToVisionMode(vec3 rgb)
+{
+    vec3 color=XYZ2xyY(RGB2XYZ(rgb));
+	///////////////////////////////////////////////////////////////////////////
+	// Now we have the xyY components in color, need to convert to RGB
+
+	// 1. Hue conversion
+	// if log10Y>0.6, photopic vision only (with the cones, colors are seen)
+	// else scotopic vision if log10Y<-2 (with the rods, no colors, everything blue),
+	// else mesopic vision (with rods and cones, transition state)
+
+    mediump vec3 resultColor;
+	if (color[2] <= 0.01)
+	{
+		// special case for s = 0 (x=0.25, y=0.25)
+		color[2] *= 0.5121445;
+		color[2] = pow(abs(color[2]*pi*0.0001), alphaWaOverAlphaDa*oneOverGamma)* term2TimesOneOverMaxdLpOneOverGamma;
+		color[0] = 0.787077*color[2];
+		color[1] = 0.9898434*color[2];
+		color[2] *= 1.9256125;
+		resultColor = color.xyz*brightnessScale;
+	}
+	else
+	{
+		if (color[2]<3.9810717055349722)
+		{
+			// Compute s, ratio between scotopic and photopic vision
+			float op = (log(color[2])/ln10 + 2.)/2.6;
+			float s = op * op *(3. - 2. * op);
+			// Do the blue shift for scotopic vision simulation (night vision) [3]
+			// The "night blue" is x,y(0.25, 0.25)
+			color[0] = (1. - s) * 0.25 + s * color[0];	// Add scotopic + photopic components
+			color[1] = (1. - s) * 0.25 + s * color[1];	// Add scotopic + photopic components
+			// Take into account the scotopic luminance approximated by V [3] [4]
+			float V = color[2] * (1.33 * (1. + color[1] / color[0] + color[0] * (1. - color[0] - color[1])) - 1.68);
+			color[2] = 0.4468 * (1. - s) * V + s * color[2];
+		}
+
+		// 2. Adapt the luminance value and scale it to fit in the RGB range [2]
+		// color[2] = std::pow(adaptLuminanceScaled(color[2]), oneOverGamma);
+		color[2] = pow(abs(color[2]*pi*0.0001), alphaWaOverAlphaDa*oneOverGamma)* term2TimesOneOverMaxdLpOneOverGamma;
+
+		// Convert from xyY to XZY
+		// Use a XYZ to Adobe RGB (1998) matrix which uses a D65 reference white
+		mediump vec3 tmp = vec3(color[0] * color[2] / color[1], color[2], (1. - color[0] - color[1]) * color[2] / color[1]);
+		resultColor = vec3(2.04148*tmp.x-0.564977*tmp.y-0.344713*tmp.z, -0.969258*tmp.x+1.87599*tmp.y+0.0415557*tmp.z, 0.0134455*tmp.x-0.118373*tmp.y+1.01527*tmp.z);
+		resultColor*=brightnessScale;
+	}core/planetsephems/de431.cpp	     core/planetsephems/de431.cpp
+     core/planetsephems/de431.hpp	     core/planetsephems/de431.hpp
+
+
+     core/modules/Atmosphere.cpp	     core/modules/AtmospherePreetham.cpp
+     core/modules/AtmospherePreetham.hpp
+     core/modules/AtmosphereBruneton.cpp
+     core/modules/AtmosphereBruneton.hpp
+     core/modules/Atmosphere.hpp	     core/modules/Atmosphere.hpp
+     core/modules/Asterism.cpp	     core/modules/Asterism.cpp
+     core/modules/Asterism.hpp	     core/modules/Asterism.hpp
+
+    return resultColor;
+}/*	/*
+ * Stellarium	 * Stellarium
+ * Copyright (C) 2003 Fabien Chereau	 * Copyright (C) 2019 Ruslan Kabatsayev
+ * Copyright (C) 2012 Timothy Reaves	
+ *	 *
+ * This program is free software; you can redistribute it and/or	 * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License	 * modify it under the terms of the GNU General Public License
+@@ -18,106 +17,53 @@
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.	 * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */	 */
+
+
+#ifndef ATMOSTPHERE_HPP	#ifndef ATMOSPHERE_HPP
+#define ATMOSTPHERE_HPP	#define ATMOSPHERE_HPP
+
+
+#include "Skylight.hpp"	#include "StelCore.hpp"
+#include "VecMath.hpp"	#include "VecMath.hpp"
+
+
+#include "Skybright.hpp"	
+#include "StelFader.hpp"	
+
+#include <QOpenGLBuffer>	
+
+class StelProjector;	
+class StelToneReproducer;	
+class StelCore;	
+
+//! Compute and display the daylight sky color using openGL.	
+//! The sky brightness is computed with the SkyBright class, the color with the SkyLight.	
+//! Don't use this class directly but use it through the LandscapeMgr.	
+class Atmosphere	class Atmosphere
+{	{
+public:	public:
+	Atmosphere();		virtual ~Atmosphere() = default;
+	virtual ~Atmosphere();	
+
+	//! Compute sky brightness values and average luminance.		//! Compute sky brightness values and average luminance.
+	void computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude, StelCore* core,		virtual void computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude, StelCore* core,
+		float latitude = 45.f, float altitude = 200.f,		                          float latitude = 45.f, float altitude = 200.f, float temperature = 15.f, float relativeHumidity = 40.f) = 0;
+		float temperature = 15.f, float relativeHumidity = 40.f);		virtual void draw(StelCore* core) = 0;
+	void draw(StelCore* core);		virtual void update(double deltaTime) = 0;
+	void update(double deltaTime) {fader.update((int)(deltaTime*1000));}	
+
+
+	//! Set fade in/out duration in seconds		//! Set fade in/out duration in seconds
+	void setFadeDuration(float duration) {fader.setDuration((int)(duration*1000.f));}		virtual void setFadeDuration(float duration) = 0;
+	//! Get fade in/out duration in seconds		//! Get fade in/out duration in seconds
+	float getFadeDuration() const {return (float)fader.getDuration()/1000.f;}		virtual float getFadeDuration() const = 0;
+
+
+	//! Define whether to display atmosphere		//! Define whether to display atmosphere
+	void setFlagShow(bool b){fader = b;}		virtual void setFlagShow(bool b) = 0;
+	//! Get whether atmosphere is displayed		//! Get whether atmosphere is displayed
+	bool getFlagShow() const {return fader;}		virtual bool getFlagShow() const = 0;
+
+
+	//! Get the actual atmosphere intensity due to eclipses + fader		//! Get the actual atmosphere intensity due to eclipses + fader
+	//! @return the display intensity ranging from 0 to 1		//! @return the display intensity ranging from 0 to 1
+	float getRealDisplayIntensityFactor() const {return fader.getInterstate()*eclipseFactor;}		virtual float getRealDisplayIntensityFactor() const = 0;
+
+/*
+ * Stellarium
+ * Copyright (C) 2019 Ruslan Kabatsayev
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */
+
+#ifndef ATMOSPHERE_BRUNETON_HPP
+#define ATMOSPHERE_BRUNETON_HPP
+
+#include "Atmosphere.hpp"
+#include "VecMath.hpp"
+
+#include "Skybright.hpp"
+#include "StelFader.hpp"
+
+#include <array>
+#include <memory>
+#include <QOpenGLBuffer>
+
+class StelProjector;
+class StelToneReproducer;
+class StelCore;
+class QOpenGLFunctions;
+
+//! Compute and display the daylight sky color using openGL.
+//! The sky brightness is computed with the SkyBright class, the color with the SkyLight.
+//! Don't use this class directly but use it through the LandscapeMgr.
+class AtmosphereBruneton : public Atmosphere
+{
+public:
+	AtmosphereBruneton();
+	~AtmosphereBruneton();
+
+	void computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude, StelCore* core,
+					  float latitude, float altitude, float temperature, float relativeHumidity) override;
+	void draw(StelCore* core) override;
+	void update(double deltaTime) override {fader.update((int)(deltaTime*1000));}
+
+	void setFadeDuration(float duration) override {fader.setDuration((int)(duration*1000.f));}
+	float getFadeDuration() const override {return (float)fader.getDuration()/1000.f;}
+
+	void setFlagShow(bool b) override {fader = b;}
+	bool getFlagShow() const override  {return fader;}
+
+	float getRealDisplayIntensityFactor() const override  {return fader.getInterstate()*eclipseFactor;}
+
+	float getFadeIntensity() const override  {return fader.getInterstate();}
+
+	float getAverageLuminance() const override  {return averageLuminance;}
+
+	void setAverageLuminance(float overrideLum) override;
+	void setLightPollutionLuminance(float f) override { lightPollutionLuminance = f; }
+	float getLightPollutionLuminance() const override { return lightPollutionLuminance; }
+
+private:
+	Vec4i viewport;
+	Skybright skyb;
+	int gridMaxY,gridMaxX;
+
+	QVector<Vec2f> posGrid;
+	QOpenGLBuffer posGridBuffer;
+	QOpenGLBuffer indexBuffer;
+	QVector<Vec4f> viewRayGrid;
+	QOpenGLBuffer viewRayGridBuffer;
+
+	//! The average luminance of the atmosphere in cd/m2
+	float averageLuminance;
+	bool overrideAverageLuminance; // if true, don't compute but keep value set via setAverageLuminance(float)
+	float eclipseFactor;
+	LinearFader fader;
+	float lightPollutionLuminance;
+
+	//! Vertex shader used for xyYToRGB computation
+	std::unique_ptr<QOpenGLShaderProgram> atmoShaderProgram;
+	struct {
+		int bayerPattern;
+		int rgbMaxValue;
+		int alphaWaOverAlphaDa;
+		int oneOverGamma;
+		int term2TimesOneOverMaxdLpOneOverGamma;
+		int brightnessScale;
+		int sunDir;
+		int cameraPos;
+		int projectionMatrix;
+		int skyVertex;
+		int viewRay;
+		int transmittanceTexture;
+		int scatteringTexture;
+		int irradianceTexture;
+		int singleMieScatteringTexture;
+	} shaderAttribLocations;
+
+	GLuint bayerPatternTex=0;
+
+	enum
+	{
+		TRANSMITTANCE_TEXTURE,
+		SCATTERING_TEXTURE,
+		IRRADIANCE_TEXTURE,
+		MIE_SCATTERING_TEXTURE,
+
+		TEX_COUNT
+	};
+	GLuint textures[TEX_COUNT];
+	Vec3d sunDir;
+	double altitude;
+	void loadTextures();
+	void loadShaders();
+	void regenerateGrid();
+	void updateEclipseFactor(StelCore* core, Vec3d sunPos, Vec3d moonPos);
+	bool separateMieTexture=false;
+
+	struct TextureSize4D
+	{
+		std::array<std::int32_t,4> sizes;
+		int muS_size() const { return sizes[0]; }
+		int mu_size() const { return sizes[1]; }
+		int nu_size() const { return sizes[2]; }
+		int r_size() const { return sizes[3]; }
+		int width() const { return muS_size(); }
+		int height() const { return mu_size(); }
+		int depth() const { return nu_size()*r_size(); }
+		bool operator!=(TextureSize4D const& rhs) const { return sizes!=rhs.sizes; }
+	};
+	struct TextureSize2D
+	{
+		std::array<std::int32_t,2> sizes;
+		int width() const { return sizes[0]; }
+		int height() const { return sizes[1]; }
+	};
+	TextureSize2D transmittanceTextureSize, irradianceTextureSize;
+	TextureSize4D scatteringTextureSize, mieScatteringTextureSize;
+
+	static TextureSize4D getTextureSize4D(QVector<char> const& data);
+	static TextureSize2D getTextureSize2D(QVector<char> const& data);  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.	 * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */	 */
+
+
+#include "Atmosphere.hpp"	#include "AtmospherePreetham.hpp"
+#include "StelUtils.hpp"	#include "StelUtils.hpp"
+#include "StelApp.hpp"	#include "StelApp.hpp"
+#include "StelProjector.hpp"	#include "StelProjector.hpp"
+@@ -32,7 +32,7 @@
+#include <QOpenGLShaderProgram>	#include <QOpenGLShaderProgram>
+
+
+
+
+Atmosphere::Atmosphere(void)	AtmospherePreetham::AtmospherePreetham(void)
+	: viewport(0,0,0,0)		: viewport(0,0,0,0)
+	, skyResolutionY(44)		, skyResolutionY(44)
+	, skyResolutionX(44)		, skyResolutionX(44)
+@@ -103,7 +103,7 @@ Atmosphere::Atmosphere(void)
+	atmoShaderProgram->release();		atmoShaderProgram->release();
+}	}
+
+
+Atmosphere::~Atmosphere(void)	AtmospherePreetham::~AtmospherePreetham(void)
+{	{
+	delete [] posGrid;		delete [] posGrid;
+	posGrid = Q_NULLPTR;		posGrid = Q_NULLPTR;
+@@ -113,7 +113,7 @@ Atmosphere::~Atmosphere(void)
+	atmoShaderProgram = Q_NULLPTR;		atmoShaderProgram = Q_NULLPTR;
+}	}
+
+
+void Atmosphere::computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude,	void AtmospherePreetham::computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude,
+							   StelCore* core, float latitude, float altitude, float temperature, float relativeHumidity)								   StelCore* core, float latitude, float altitude, float temperature, float relativeHumidity)
+{	{
+	const StelProjectorP prj = core->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);		const StelProjectorP prj = core->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
+@@ -316,7 +316,7 @@ void Atmosphere::computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moo
+
+
+// override computable luminance. This is for special operations only, e.g. for scripting of brightness-balanced image export.	// override computable luminance. This is for special operations only, e.g. for scripting of brightness-balanced image export.
+// To return to auto-computed values, set any negative value.	// To return to auto-computed values, set any negative value.
+void Atmosphere::setAverageLuminance(float overrideLum)	void AtmospherePreetham::setAverageLuminance(float overrideLum)
+{	{
+	if (overrideLum<0.f)		if (overrideLum<0.f)
+	{		{
+@@ -331,7 +331,7 @@ void Atmosphere::setAverageLuminance(float overrideLum)
+}	}
+
+
+// Draw the atmosphere using the precalc values stored in tab_sky	// Draw the atmosphere using the precalc values stored in tab_sky
+void Atmosphere::draw(StelCore* core)	void AtmospherePreetham::draw(StelCore* core)
+{	{
+	if (StelApp::getInstance().getVisionModeNight())		if (StelApp::getInstance().getVisionModeNight())
+		return;			return;
+@@ -409,6 +409,6 @@ void Atmosphere::draw(StelCore* core)
+	//StelPainter painter(prj);		//StelPainter painter(prj);
+	//painter.setFont(font);		//painter.setFont(font);
+	//sPainter.setColor(0.7, 0.7, 0.7);		//sPainter.setColor(0.7, 0.7, 0.7);
+	//sPainter.drawText(83, 120, QString("Atmosphere::getAverageLuminance(): %1" ).arg(getAverageLuminance()));		//sPainter.drawText(83, 120, QString("AtmospherePreetham::getAverageLuminance(): %1" ).arg(getAverageLuminance()));
+	//qDebug() << atmosphere->getAverageLuminance();		//qDebug() << atmosphere->getAverageLuminance();
+}	} /*
+ * Stellarium
+ * Copyright (C) 2003 Fabien Chereau
+ * Copyright (C) 2012 Timothy Reaves 
+ *#include "Atmosphere.hpp"
+ * This program is free software; you can redistribute it and/or AtmospherePreetham. "AtmosphereBruneton.hpp"
+ * modify it under the terms of the GNU General Public License 	const auto atmosphereModelConfig=conf->value("landscape/atmosphere_model", "preetham").toString();
+	if(atmosphereModelConfig=="preetham")
+		atmosphere = new AtmospherePreetham();
+	else if(atmosphereModelConfig=="bruneton")
+		atmosphere = new AtmosphereBruneton();    
+	else    ########### install files ###############	########### install files ###############
+
+
+INSTALL(DIRECTORY ./ DESTINATION ${SDATALOC}/textures	INSTALL(DIRECTORY ./ DESTINATION ${SDATALOC}/textures
+        FILES_MATCHING PATTERN "*.png"	        FILES_MATCHING PATTERN "*.png" PATTERN "atmosphere/*.dat"
+        PATTERN "CMakeFiles" EXCLUDE )	        PATTERN "CMakeFiles" EXCLUDE )
+
+	{
+		qWarning() << "Unsupported atmosphere model" << atmosphereModelConfig;
+		atmosphere = new AtmospherePreetham();
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */
+
+#ifndef ATMOSPHERE_PREETHAM_HPP
+#define ATMOSPHERE_PREETHAM_HPP
+
+#include "Atmosphere.hpp"
+#include "Skylight.hpp"
+#include "VecMath.hpp"
+
+#include "Skybright.hpp"
+#include "StelFader.hpp"
+
+#include <QOpenGLBuffer>
+
+class StelProjector;
+class StelToneReproducer;
+class StelCore;
+
+//! Compute and display the daylight sky color using openGL.
+//! The sky brightness is computed with the SkyBright class, the color with the SkyLight.
+//! Don't use this class directly but use it through the LandscapeMgr.
+class AtmospherePreetham : public Atmosphere
+{
+public:
+	AtmospherePreetham();
+	virtual ~AtmospherePreetham();
+
+	//! Compute sky brightness values and average luminance.
+	void computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude, StelCore* core,
+		float latitude = 45.f, float altitude = 200.f,
+		float temperature = 15.f, float relativeHumidity = 40.f);
+	void draw(StelCore* core);
+	void update(double deltaTime) {fader.update((int)(deltaTime*1000));}
+
+	//! Set fade in/out duration in seconds
+	void setFadeDuration(float duration) {fader.setDuration((int)(duration*1000.f));}
+	//! Get fade in/out duration in seconds
+	float getFadeDuration() const {return (float)fader.getDuration()/1000.f;}
+
+	//! Define whether to display atmosphere
+	void setFlagShow(bool b){fader = b;}
+	//! Get whether atmosphere is displayed
+	bool getFlagShow() const {return fader;}
+
+	//! Get the actual atmosphere intensity due to eclipses + fader
+	//! @return the display intensity ranging from 0 to 1
+	float getRealDisplayIntensityFactor() const {return fader.getInterstate()*eclipseFactor;}
+
+	// lets you know how far faded in or out the atmosphere is (0..1)
+	float getFadeIntensity() const {return fader.getInterstate();}
+
+	//! Get the average luminance of the atmosphere in cd/m2
+	//! If atmosphere is off, the luminance equals the background starlight (0.001cd/m2).
+	// TODO: Find reference for this value? Why 1 mcd/m2 without atmosphere and 0.1 mcd/m2 inside? Absorption?
+	//! Otherwise it includes the (atmosphere + background starlight (0.0001cd/m2) * eclipse factor + light pollution.
+	//! @return the last computed average luminance of the atmosphere in cd/m2.
+	float getAverageLuminance() const {return averageLuminance;}
+
+	//! override computable luminance. This is for special operations only, e.g. for scripting of brightness-balanced image export.
+	//! To return to auto-computed values, set any negative value at the end of the script.
+	void setAverageLuminance(float overrideLum);
+	//! Set the light pollution luminance in cd/m^2
+	void setLightPollutionLuminance(float f) { lightPollutionLuminance = f; }
+	//! Get the light pollution luminance in cd/m^2
+	float getLightPollutionLuminance() const { return lightPollutionLuminance; }
+
+private:
+	Vec4i viewport;
+	Skylight sky;
+	Skybright skyb;
+	int skyResolutionY,skyResolutionX;
+
+	Vec2f* posGrid;
+	QOpenGLBuffer posGridBuffer;
+	QOpenGLBuffer indicesBuffer;
+	Vec4f* colorGrid;
+	QOpenGLBuffer colorGridBuffer;
+
+	//! The average luminance of the atmosphere in cd/m2
+	float averageLuminance;
+	bool overrideAverageLuminance; // if true, don't compute but keep value set via setAverageLuminance(float)
+	float eclipseFactor;
+	LinearFader fader;
+	float lightPollutionLuminance;
+
+	//! Vertex shader used for xyYToRGB computation
+	class QOpenGLShaderProgram* atmoShaderProgram;
+	struct {
+		int bayerPattern;
+		int rgbMaxValue;
+		int alphaWaOverAlphaDa;
+		int oneOverGamma;
+		int term2TimesOneOverMaxdLpOneOverGamma;
+		int brightnessScale;
+		int sunPos;
+		int term_x, Ax, Bx, Cx, Dx, Ex;
+		int term_y, Ay, By, Cy, Dy, Ey;
+		int projectionMatrix;
+		int skyVertex;
+		int skyColor;
+	} shaderAttribLocations;
+
+	GLuint bayerPatternTex=0;
+};
+
+#endif // ATMOSTPHERE_HPP
+};
+
+#endif // ATMOSTPHERE_HPP
+	// lets you know how far faded in or out the atmosphere is (0..1)		// lets you know how far faded in or out the atmosphere is (0..1)
+	float getFadeIntensity() const {return fader.getInterstate();}		virtual float getFadeIntensity() const = 0;
+
+
+	//! Get the average luminance of the atmosphere in cd/m2		/*!
+	//! If atmosphere is off, the luminance equals the background starlight (0.001cd/m2).		 * Get the average luminance of the atmosphere in cd/m2
+	// TODO: Find reference for this value? Why 1 mcd/m2 without atmosphere and 0.1 mcd/m2 inside? Absorption?		 * If atmosphere is off, the luminance equals the background starlight (0.001cd/m2).
+	//! Otherwise it includes the (atmosphere + background starlight (0.0001cd/m2) * eclipse factor + light pollution.		 * Otherwise it includes the (atmosphere + background starlight (0.0001cd/m2) * eclipse factor + light pollution.
+	//! @return the last computed average luminance of the atmosphere in cd/m2.		 * @return the last computed average luminance of the atmosphere in cd/m2.
+	float getAverageLuminance() const {return averageLuminance;}		 */
+
+	virtual float getAverageLuminance() const = 0;
+	//! override computable luminance. This is for special operations only, e.g. for scripting of brightness-balanced image export.		//! override computable luminance. This is for special operations only, e.g. for scripting of brightness-balanced image export.
+	//! To return to auto-computed values, set any negative value at the end of the script.		//! To return to auto-computed values, set any negative value at the end of the script.
+	void setAverageLuminance(float overrideLum);		virtual void setAverageLuminance(float overrideLum) = 0;
+	//! Set the light pollution luminance in cd/m^2		//! Set the light pollution luminance in cd/m^2
+	void setLightPollutionLuminance(float f) { lightPollutionLuminance = f; }		virtual void setLightPollutionLuminance(float f) = 0;
+	//! Get the light pollution luminance in cd/m^2		//! Get the light pollution luminance in cd/m^2
+	float getLightPollutionLuminance() const { return lightPollutionLuminance; }		virtual float getLightPollutionLuminance() const = 0;
+
+private:	
+	Vec4i viewport;	
+	Skylight sky;	
+	Skybright skyb;	
+	int skyResolutionY,skyResolutionX;	
+
+	Vec2f* posGrid;	
+	QOpenGLBuffer posGridBuffer;	
+	QOpenGLBuffer indicesBuffer;	
+	Vec4f* colorGrid;	
+	QOpenGLBuffer colorGridBuffer;	
+
+	//! The average luminance of the atmosphere in cd/m2	
+	float averageLuminance;	
+	bool overrideAverageLuminance; // if true, don't compute but keep value set via setAverageLuminance(float)	
+	float eclipseFactor;	
+	LinearFader fader;	
+	float lightPollutionLuminance;	
+
+	//! Vertex shader used for xyYToRGB computation	
+	class QOpenGLShaderProgram* atmoShaderProgram;	
+	struct {	
+		int bayerPattern;	
+		int rgbMaxValue;	
+		int alphaWaOverAlphaDa;	
+		int oneOverGamma;	
+		int term2TimesOneOverMaxdLpOneOverGamma;	
+		int brightnessScale;	
+		int sunPos;	
+		int term_x, Ax, Bx, Cx, Dx, Ex;	
+		int term_y, Ay, By, Cy, Dy, Ey;	
+		int projectionMatrix;	
+		int skyVertex;	
+		int skyColor;	
+	} shaderAttribLocations;	
+
+	GLuint bayerPatternTex=0;	
+};	};
+
+
+#endif // ATMOSTPHERE_HPP	#endif
+    view_ray = viewRay.xyz;
+	gl_Position = projectionMatrix*vec4(vertex, 0., 1.);
+}
 void main()
 {
     highp vec3 xyy;


### PR DESCRIPTION
/* Stellarium Web Engine - Copyright (c) 2018 - Noctua Software Ltd
 *
 * This program is licensed under the terms of the GNU AGPL v3, or
 * alternatively under a commercial licence.
 *
 * The terms of the AGPL v3 license can be found in the main directory of this
 * repository.
 */

#ifdef GL_ES
precision mediump float;
#endif

uniform highp float u_atm_p[12];
uniform highp vec3  u_sun;
uniform highp float u_tm[3]; // Tonemapping koefs.

varying lowp    vec4        v_color;

#ifdef VERTEX_SHADER

attribute highp   vec4       a_pos;
attribute highp   vec3       a_sky_pos;
attribute highp   float      a_luminance;

highp float gammaf(highp float c)
{
    if (c < 0.0031308)
      return 19.92 * c;
    return 1.055 * pow(c, 1.0 / 2.4) - 0.055;
}

vec3 xyy_to_srgb(highp vec3 xyy)
{
    const highp mat3 xyz_to_rgb = mat3(3.2406, -0.9689, 0.0557,
                                      -1.5372, 1.8758, -0.2040,
                                      -0.4986, 0.0415, 1.0570);
    highp vec3 xyz = vec3(xyy[0] * xyy[2] / xyy[1], xyy[2],
               (1.0 - xyy[0] - xyy[1]) * xyy[2] / xyy[1]);
    highp vec3 srgb = xyz_to_rgb * xyz;
    clamp(srgb, 0.0, 1.0);
    return srgb;
}

void main()
{
    highp vec3 xyy;
    highp float cos_gamma, cos_gamma2, gamma, cos_theta;
    highp vec3 p = a_sky_pos;

    gl_Position = a_pos;

    // First compute the xy color component (chromaticity) from Preetham model
    // and re-inject a_luminance for Y component (luminance).
    p[2] = abs(p[2]); // Mirror below horizon.
    cos_gamma = dot(p, u_sun);
    cos_gamma2 = cos_gamma * cos_gamma;
    gamma = acos(cos_gamma);
    cos_theta = p[2];

    xyy.x = ((1. + u_atm_p[0] * exp(u_atm_p[1] / cos_theta)) *
             (1. + u_atm_p[2] * exp(u_atm_p[3] * gamma) +
              u_atm_p[4] * cos_gamma2)) * u_atm_p[5];
    xyy.y = ((1. + u_atm_p[6] * exp(u_atm_p[7] / cos_theta)) *
             (1. + u_atm_p[8] * exp(u_atm_p[9] * gamma) +HEADERS := $(shell find $(DIRS) -name "*.h")	HEADERS := $(shell find $(DIRS) -name "*.h")
SOURCES := $(shell find $(DIRS) -name "*.cc")	SOURCES := $(shell find $(DIRS) -name "*.cc")
GLSL_SOURCES := $(shell find $(DIRS) -name "*.glsl")	GLSL_SOURCES := $(shell find $(DIRS) -name "*.glsl")
DOC_SOURCES := $(HEADERS) $(SOURCES) $(GLSL_SOURCES) index	JS_SOURCES := $(shell find $(DIRS) -name "*.js")
DOC_SOURCES := $(HEADERS) $(SOURCES) $(GLSL_SOURCES) $(JS_SOURCES) index


all: lint doc test integration_test demo	all: lint doc test integration_test webgl demo


# cpplint can be installed with "pip install cpplint".	# cpplint can be installed with "pip install cpplint".
# We exclude runtime/references checking for functions.h and model_test.cc	# We exclude runtime/references checking for functions.h and model_test.cc
@@ -66,6 +67,8 @@ integration_test: output/Release/atmosphere_integration_test
	mkdir -p output/Doc/atmosphere/reference		mkdir -p output/Doc/atmosphere/reference
	output/Release/atmosphere_integration_test		output/Release/atmosphere_integration_test


webgl: output/Doc/scattering.dat output/Doc/demo.html output/Doc/demo.js

demo: output/Debug/atmosphere_demo	demo: output/Debug/atmosphere_demo
	output/Debug/atmosphere_demo		output/Debug/atmosphere_demo


@@ -77,6 +80,18 @@ output/Doc/%.html: % output/Debug/tools/docgen tools/docgen_template.html
	mkdir -p $(@D)		mkdir -p $(@D)
	output/Debug/tools/docgen $< tools/docgen_template.html $@		output/Debug/tools/docgen $< tools/docgen_template.html $@


output/Doc/scattering.dat: output/Debug/precompute
	mkdir -p $(@D)
	output/Debug/precompute $(@D)/

output/Doc/demo.html: atmosphere/demo/webgl/demo.html
	mkdir -p $(@D)
	cp $< $@

output/Doc/demo.js: atmosphere/demo/webgl/demo.js
	mkdir -p $(@D)
	cp $< $@

output/Debug/tools/docgen: output/Debug/tools/docgen_main.o	output/Debug/tools/docgen: output/Debug/tools/docgen_main.o
	$(GPP) $< -o $@		$(GPP) $< -o $@


@@ -96,6 +111,14 @@ output/Release/atmosphere_integration_test: \
    output/Release/external/progress_bar/util/progress_bar.o	    output/Release/external/progress_bar/util/progress_bar.o
	$(GPP) $^ -pthread -ldl -lglut -lGL -o $@		$(GPP) $^ -pthread -ldl -lglut -lGL -o $@


output/Debug/precompute: \
    output/Debug/atmosphere/demo/demo.o \
    output/Debug/atmosphere/demo/webgl/precompute.o \
    output/Debug/atmosphere/model.o \
    output/Debug/text/text_renderer.o \
    output/Debug/external/glad/src/glad.o
	$(GPP) $^ -pthread -ldl -lglut -lGL -o $@

output/Debug/atmosphere_demo: \	output/Debug/atmosphere_demo: \
    output/Debug/atmosphere/demo/demo.o \	    output/Debug/atmosphere/demo/demo.o \
    output/Debug/atmosphere/demo/demo_main.o \	    output/Debug/atmosphere/demo/demo_main.o \
 28  atmosphere/demo/demo.cc 
@@ -170,6 +170,8 @@ Demo::Demo(int viewport_width, int viewport_height) :
*/	*/


Demo::~Demo() {	Demo::~Demo() {
  glDeleteShader(vertex_shader_);
  glDeleteShader(fragment_shader_);
  glDeleteProgram(program_);	  glDeleteProgram(program_);
  glDeleteBuffers(1, &full_screen_quad_vbo_);	  glDeleteBuffers(1, &full_screen_quad_vbo_);
  glDeleteVertexArrays(1, &full_screen_quad_vao_);	  glDeleteVertexArrays(1, &full_screen_quad_vao_);
@@ -287,10 +289,10 @@ our demo scene, and link them with the <code>Model</code>'s atmosphere shader
to get the final scene rendering program:	to get the final scene rendering program:
*/	*/


  GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);	  vertex_shader_ = glCreateShader(GL_VERTEX_SHADER);
  const char* const vertex_shader_source = kVertexShader;	  const char* const vertex_shader_source = kVertexShader;
  glShaderSource(vertex_shader, 1, &vertex_shader_source, NULL);	  glShaderSource(vertex_shader_, 1, &vertex_shader_source, NULL);
  glCompileShader(vertex_shader);	  glCompileShader(vertex_shader_);


  const std::string fragment_shader_str =	  const std::string fragment_shader_str =
      "#version 330\n" +	      "#version 330\n" +
@@ -299,23 +301,21 @@ to get the final scene rendering program:
      std::to_string(kLengthUnitInMeters) + ";\n" +	      std::to_string(kLengthUnitInMeters) + ";\n" +
      demo_glsl;	      demo_glsl;
  const char* fragment_shader_source = fragment_shader_str.c_str();	  const char* fragment_shader_source = fragment_shader_str.c_str();
  GLuint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);	  fragment_shader_ = glCreateShader(GL_FRAGMENT_SHADER);
  glShaderSource(fragment_shader, 1, &fragment_shader_source, NULL);	  glShaderSource(fragment_shader_, 1, &fragment_shader_source, NULL);
  glCompileShader(fragment_shader);	  glCompileShader(fragment_shader_);


  if (program_ != 0) {	  if (program_ != 0) {
    glDeleteProgram(program_);	    glDeleteProgram(program_);
  }	  }
  program_ = glCreateProgram();	  program_ = glCreateProgram();
  glAttachShader(program_, vertex_shader);	  glAttachShader(program_, vertex_shader_);
  glAttachShader(program_, fragment_shader);	  glAttachShader(program_, fragment_shader_);
  glAttachShader(program_, model_->GetShader());	  glAttachShader(program_, model_->shader());
  glLinkProgram(program_);	  glLinkProgram(program_);
  glDetachShader(program_, vertex_shader);	  glDetachShader(program_, vertex_shader_);
  glDetachShader(program_, fragment_shader);	  glDetachShader(program_, fragment_shader_);
  glDetachShader(program_, model_->GetShader());	  glDetachShader(program_, model_->shader());
  glDeleteShader(vertex_shader);	
  glDeleteShader(fragment_shader);	


/*	/*
<p>Finally, it sets the uniforms of this program that can be set once and for	<p>Finally, it sets the uniforms of this program that can be set once and for
 7  atmosphere/demo/demo.glsl 
@@ -47,7 +47,7 @@ uniform vec3 earth_center;
uniform vec3 sun_direction;	uniform vec3 sun_direction;
uniform vec2 sun_size;	uniform vec2 sun_size;
in vec3 view_ray;	in vec3 view_ray;
layout(location = 0) out vec3 color;	layout(location = 0) out vec4 color;


/*	/*
<p>It uses the following constants, as well as the following atmosphere	<p>It uses the following constants, as well as the following atmosphere
@@ -381,6 +381,7 @@ the scene:
  }	  }
  radiance = mix(radiance, ground_radiance, ground_alpha);	  radiance = mix(radiance, ground_radiance, ground_alpha);
  radiance = mix(radiance, sphere_radiance, sphere_alpha);	  radiance = mix(radiance, sphere_radiance, sphere_alpha);
  color =	  color.rgb = 
     pow(vec3(1.0) - exp(-radiance / white_point * exposure), vec3(1.0 / 2.2));	      pow(vec3(1.0) - exp(-radiance / white_point * exposure), vec3(1.0 / 2.2));
  color.a = 1.0;
}	}
 9  atmosphere/demo/demo.h 
@@ -55,6 +55,11 @@ class Demo {
  Demo(int viewport_width, int viewport_height);	  Demo(int viewport_width, int viewport_height);
  ~Demo();	  ~Demo();


  const Model& model() const { return *model_; }
  const GLuint vertex_shader() const { return vertex_shader_; }
  const GLuint fragment_shader() const { return fragment_shader_; }
  const GLuint program() const { return program_; }

 private:	 private:
  enum Luminance {	  enum Luminance {
    // Render the spectral radiance at kLambdaR, kLambdaG, kLambdaB.	    // Render the spectral radiance at kLambdaR, kLambdaG, kLambdaB.
@@ -91,7 +96,9 @@ class Demo {
  bool show_help_;	  bool show_help_;


  std::unique_ptr<Model> model_;	  std::unique_ptr<Model> model_;
  unsigned int program_;	  GLuint vertex_shader_;
  GLuint fragment_shader_;
  GLuint program_;
  GLuint full_screen_quad_vao_;	  GLuint full_screen_quad_vao_;
  GLuint full_screen_quad_vbo_;	  GLuint full_screen_quad_vbo_;
  std::unique_ptr<TextRenderer> text_renderer_;	  std::unique_ptr<TextRenderer> text_renderer_;
 51  atmosphere/demo/webgl/demo.html 
@@ -0,0 +1,51 @@
<html>
  <head>
    <meta charset="utf-8">
    <title>Precomputed Atmospheric Scattering - WebGL Demo</title>
    <script type="text/javascript" src="demo.js"></script>
    <style>
      html, body {
        position: relative;
        width: 100%;
        height: 100%;
        padding: 0;
        margin: 0;
        overflow: hidden;
      }
      #help {
        position: absolute;
        top: 0;
        left: 0;
        color: red;
        font-family: monospace;
      }
      ul {
        padding-left: 1em;
      }
      li {
        list-style: none;
      }
    </style>
  </head>
  <body onload="new Demo(document.body);">
    <canvas id="glcanvas" width="400" height="300"></canvas>
    <ul id="help">
      <li>
        <a href="index.html">Precomputed Atmospheric Scattering - WebGL Demo</a>
      </li>
      <li>&nbsp;</li>
      <li>Mouse:
        <ul>
          <li>drag, CTRL+drag, wheel: view and sun directions</li>
        </ul>
      </li>
      <li>Keys:
        <ul>
          <li>h: help</li>
          <li>+/-: increase/decrease exposure</li>
          <li>1-9: predefined views</li>
        </ul>
      </li>
    </ul>
  </body>
</html>
 387  atmosphere/demo/webgl/demo.js 
@@ -0,0 +1,387 @@
/**
 * Copyright (c) 2018 Eric Bruneton
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
 * are met:
 * 1. Redistributions of source code must retain the above copyright
 *    notice, this list of conditions and the following disclaimer.
 * 2. Redistributions in binary form must reproduce the above copyright
 *    notice, this list of conditions and the following disclaimer in the
 *    documentation and/or other materials provided with the distribution.
 * 3. Neither the name of the copyright holders nor the names of its
 *    contributors may be used to endorse or promote products derived from
 *    this software without specific prior written permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 * THE POSSIBILITY OF SUCH DAMAGE.
 */

/*<h2>atmosphere/demo/webgl/demo.js</h2>
<p>This file is a Javascript transcription of the original
<a href="../demo.cc.html">C++</a> code of the demo, where the code related to
the atmosphere model initialisation is replaced with code to load precomputed
textures and shaders from the network (those are precomputed with
<a href="precompute.cc.html">precompute.cc</a>).
<p>The following constants must have the same values as in
<a href="../../constants.h.html">constants.h</a> and
<a href="../demo.cc.html">demo.cc</a>:
*/

const TRANSMITTANCE_TEXTURE_WIDTH = 256;
const TRANSMITTANCE_TEXTURE_HEIGHT = 64;
const SCATTERING_TEXTURE_WIDTH = 256;
const SCATTERING_TEXTURE_HEIGHT = 128;
const SCATTERING_TEXTURE_DEPTH = 32;
const IRRADIANCE_TEXTURE_WIDTH = 64;
const IRRADIANCE_TEXTURE_HEIGHT = 16;

const kSunAngularRadius = 0.00935 / 2;
const kSunSolidAngle = Math.PI * kSunAngularRadius * kSunAngularRadius;
const kLengthUnitInMeters = 1000;

/*
<p>As in the C++ version, the code consists in a single class. Its constructor
initializes the WebGL canvas, declares the fields of the class, sets up the
event handlers and starts the resource loading and the render loop:
*/

class Demo {
  constructor(rootElement) {
    this.canvas = rootElement.querySelector('#glcanvas');
    this.canvas.style.width = `${rootElement.clientWidth}px`;
    this.canvas.style.height = `${rootElement.clientHeight}px`;
    this.canvas.width = rootElement.clientWidth * window.devicePixelRatio;
    this.canvas.height = rootElement.clientHeight * window.devicePixelRatio;
    this.help = rootElement.querySelector('#help');
    this.gl = this.canvas.getContext('webgl2');

    this.vertexBuffer = null;
    this.transmittanceTexture = null;
    this.scatteringTexture = null;
    this.irradianceTexture = null;
    this.vertexShaderSource = null;
    this.fragmentShaderSource = null;
    this.atmosphereShaderSource = null;
    this.program = null;

    this.viewFromClip = new Float32Array(16);
    this.modelFromView = new Float32Array(16);
    this.viewDistanceMeters = 9000;
    this.viewZenithAngleRadians = 1.47;
    this.viewAzimuthAngleRadians = -0.1;
    this.sunZenithAngleRadians = 1.3;
    this.sunAzimuthAngleRadians = 2.9;
    this.exposure = 10;

    this.drag = undefined;
    this.previousMouseX = undefined;
    this.previousMouseY = undefined;

    rootElement.addEventListener('keypress', (e) => this.onKeyPress(e));
    rootElement.addEventListener('mousedown', (e) => this.onMouseDown(e));
    rootElement.addEventListener('mousemove', (e) => this.onMouseMove(e));
    rootElement.addEventListener('mouseup', (e) => this.onMouseUp(e));
    rootElement.addEventListener('wheel', (e) => this.onMouseWheel(e));

    this.init();
    requestAnimationFrame(() => this.onRender());
  }

/*
<p>The init method creates a vertex buffer for a full screen quad, and loads the
precomputed textures and the shaders for the demo (using utility methods defined
in the <code>Utils</code> class below):
*/

  init() {
    const gl = this.gl;
    this.vertexBuffer = gl.createBuffer();
    gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer);
    gl.bufferData(gl.ARRAY_BUFFER,
       new Float32Array([-1, -1, +1, -1, -1, +1, +1, +1]), gl.STATIC_DRAW);

    Utils.loadTextureData('transmittance.dat', (data) => {
      this.transmittanceTexture =
          Utils.createTexture(gl, gl.TEXTURE0, gl.TEXTURE_2D);
      gl.texImage2D(gl.TEXTURE_2D, 0,
          gl.getExtension('OES_texture_float_linear') ? gl.RGBA32F : gl.RGBA16F,
          TRANSMITTANCE_TEXTURE_WIDTH, TRANSMITTANCE_TEXTURE_HEIGHT, 0, gl.RGBA,
          gl.FLOAT, data);
    });
    Utils.loadTextureData('scattering.dat', (data) => {
      this.scatteringTexture =
          Utils.createTexture(gl, gl.TEXTURE1, gl.TEXTURE_3D);
      gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE);
      gl.texImage3D(gl.TEXTURE_3D, 0, gl.RGBA16F, SCATTERING_TEXTURE_WIDTH,
          SCATTERING_TEXTURE_HEIGHT, SCATTERING_TEXTURE_DEPTH, 0, gl.RGBA,
          gl.FLOAT, data);
    });
    Utils.loadTextureData('irradiance.dat', (data) => {
      this.irradianceTexture =
          Utils.createTexture(gl, gl.TEXTURE2, gl.TEXTURE_2D);
      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA16F, IRRADIANCE_TEXTURE_WIDTH,
          IRRADIANCE_TEXTURE_HEIGHT, 0, gl.RGBA, gl.FLOAT, data);
    });

    Utils.loadShaderSource('vertex_shader.txt', (source) => {
      this.vertexShaderSource = source;
    });
    Utils.loadShaderSource('fragment_shader.txt', (source) => {
      this.fragmentShaderSource = source;
    });
    Utils.loadShaderSource('atmosphere_shader.txt', (source) => {
      this.atmosphereShaderSource = source;
    });
  }

/*
<p>The WebGL program cannot be created before all the shaders are loaded. This
is done in the following method, which is called at each frame (the precomputed
shaders are OpenGL 3.3 shaders, so they must be adapted for WebGL2. In
particular, the version id must be changed, and the fragment shaders must be
concatenated because WebGL2 does not support multiple shaders of the same type):
*/

  maybeInitProgram() {
    if (this.program ||
        !this.vertexShaderSource ||
        !this.fragmentShaderSource ||
        !this.atmosphereShaderSource) {
      return;
    }
    const gl = this.gl;
    const vertexShader =
        Utils.createShader(gl, gl.VERTEX_SHADER,
            this.vertexShaderSource.replace('#version 330', '#version 300 es'));
    const fragmentShader = Utils.createShader(
        gl,
        gl.FRAGMENT_SHADER,
        this.atmosphereShaderSource
            .replace('#version 330',
                     '#version 300 es\n' +
                     'precision highp float;\n' +
                     'precision highp sampler3D;') +
        this.fragmentShaderSource
            .replace('#version 330', '')
            .replace('const float PI = 3.14159265;', '')
        );
    this.program = gl.createProgram();
    gl.attachShader(this.program, vertexShader);
    gl.attachShader(this.program, fragmentShader);
    gl.linkProgram(this.program);
  }

/*
<p>The render loop body sets the program attributes and uniforms, and renders
a full screen quad with it:
*/

  onRender() {
    const gl = this.gl;
    gl.clearColor(0, 0, 0, 1);
    gl.clear(gl.COLOR_BUFFER_BIT);

    this.maybeInitProgram();
    if (!this.program) {
      requestAnimationFrame(() => this.onRender());
      return;
    }

    const kFovY = 50 / 180 * Math.PI;
    const kTanFovY = Math.tan(kFovY / 2);
    const aspectRatio = this.canvas.width / this.canvas.height;
    this.viewFromClip.set([
        kTanFovY * aspectRatio, 0, 0, 0,
        0, kTanFovY, 0, 0,
        0, 0, 0, -1,
        0, 0, 1, 1]);

    const cosZ = Math.cos(this.viewZenithAngleRadians);
    const sinZ = Math.sin(this.viewZenithAngleRadians);
    const cosA = Math.cos(this.viewAzimuthAngleRadians);
    const sinA = Math.sin(this.viewAzimuthAngleRadians);
    const viewDistance = this.viewDistanceMeters / kLengthUnitInMeters;
    this.modelFromView.set([
        -sinA, -cosZ * cosA,  sinZ * cosA, sinZ * cosA * viewDistance,
        cosA, -cosZ * sinA, sinZ * sinA, sinZ * sinA * viewDistance,
        0, sinZ, cosZ, cosZ * viewDistance,
        0, 0, 0, 1]);

    const program = this.program;
    gl.useProgram(program);
    gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer);
    gl.vertexAttribPointer(
        gl.getAttribLocation(program, 'vertex'),
        /*numComponents=*/ 2,
        /*type=*/ this.gl.FLOAT,
        /*normalize=*/ false,
        /*stride=*/ 0,
        /*offset=*/ 0);
    gl.enableVertexAttribArray(gl.getAttribLocation(program, 'vertex'));
    gl.uniformMatrix4fv(gl.getUniformLocation(program, 'view_from_clip'),
        true,  this.viewFromClip);
    gl.uniformMatrix4fv(gl.getUniformLocation(program, 'model_from_view'),
        true,  this.modelFromView);
    gl.uniform1i(gl.getUniformLocation(program, 'transmittance_texture'), 0);
    gl.uniform1i(gl.getUniformLocation(program, 'scattering_texture'), 1);
    gl.uniform1i(gl.getUniformLocation(program, 'irradiance_texture'), 2);
    gl.uniform3f(gl.getUniformLocation(program, 'camera'),
        this.modelFromView[3], this.modelFromView[7], this.modelFromView[11]);
    gl.uniform3f(gl.getUniformLocation(program, 'white_point'), 1, 1, 1);
    gl.uniform1f(gl.getUniformLocation(program, 'exposure'), this.exposure);
    gl.uniform3f(gl.getUniformLocation(program, 'earth_center'),
        0, 0, -6360000 / kLengthUnitInMeters);
    gl.uniform3f(gl.getUniformLocation(program, 'sun_direction'),
        Math.cos(this.sunAzimuthAngleRadians) *
            Math.sin(this.sunZenithAngleRadians),
        Math.sin(this.sunAzimuthAngleRadians) *
            Math.sin(this.sunZenithAngleRadians),
        Math.cos(this.sunZenithAngleRadians));
    gl.uniform2f(gl.getUniformLocation(program, 'sun_size'),
        Math.tan(kSunAngularRadius), Math.cos(kSunAngularRadius));
    gl.drawArrays(gl.TRIANGLE_STRIP, /*offset=*/ 0, /*vertexCount=*/ 4);
    requestAnimationFrame(() => this.onRender());
  }

/*
<p>The last part of the Demo class are the event handler methods, which are
directly adapted from the C++ code:
*/

  onKeyPress(event) {
    const key = event.key;
    if (key == 'h') {
      const hidden = this.help.style.display == 'none';
      this.help.style.display = hidden ? 'block' : 'none';
    } else if (key == '+') {
      this.exposure *= 1.1;
    } else if (key == '-') {
      this.exposure /= 1.1;
    } else if (key == '1') {
      this.setView(9000, 1.47, 0, 1.3, 3, 10);
    } else if (key == '2') {
      this.setView(9000, 1.47, 0, 1.564, -3, 10);
    } else if (key == '3') {
      this.setView(7000, 1.57, 0, 1.54, -2.96, 10);
    } else if (key == '4') {
      this.setView(7000, 1.57, 0, 1.328, -3.044, 10);
    } else if (key == '5') {
      this.setView(9000, 1.39, 0, 1.2, 0.7, 10);
    } else if (key == '6') {
      this.setView(9000, 1.5, 0, 1.628, 1.05, 200);
    } else if (key == '7') {
      this.setView(7000, 1.43, 0, 1.57, 1.34, 40);
    } else if (key == '8') {
      this.setView(2.7e6, 0.81, 0, 1.57, 2, 10);
    } else if (key == '9') {
      this.setView(1.2e7, 0.0, 0, 0.93, -2, 10);
    }
  }

  setView(viewDistanceMeters, viewZenithAngleRadians, viewAzimuthAngleRadians,
      sunZenithAngleRadians, sunAzimuthAngleRadians, exposure) {
    this.viewDistanceMeters = viewDistanceMeters;
    this.viewZenithAngleRadians = viewZenithAngleRadians;
    this.viewAzimuthAngleRadians = viewAzimuthAngleRadians;
    this.sunZenithAngleRadians = sunZenithAngleRadians;
    this.sunAzimuthAngleRadians = sunAzimuthAngleRadians;
    this.exposure = exposure;
  }

  onMouseDown(event) {
    this.previousMouseX = event.offsetX;
    this.previousMouseY = event.offsetY;
    this.drag = event.ctrlKey ? 'sun' : 'camera';
  }

  onMouseMove(event) {
    const kScale = 500;
    const mouseX = event.offsetX;
    const mouseY = event.offsetY;
    if (this.drag == 'sun') {
      this.sunZenithAngleRadians -= (this.previousMouseY - mouseY) / kScale;
      this.sunZenithAngleRadians =
        Math.max(0, Math.min(Math.PI, this.sunZenithAngleRadians));
      this.sunAzimuthAngleRadians += (this.previousMouseX - mouseX) / kScale;
    } else if (this.drag == 'camera') {
      this.viewZenithAngleRadians += (this.previousMouseY - mouseY) / kScale;
      this.viewZenithAngleRadians =
          Math.max(0, Math.min(Math.PI / 2, this.viewZenithAngleRadians));
      this.viewAzimuthAngleRadians += (this.previousMouseX - mouseX) / kScale;
    }
    this.previousMouseX = mouseX;
    this.previousMouseY = mouseY;
  }

  onMouseUp(event) {
    this.drag = undefined;
  }

  onMouseWheel(event) {
    this.viewDistanceMeters *= event.deltaY > 0 ? 1.05 : 1 / 1.05;
  }
}

/*
<p>The <code>Utils</code> class used above provides 4 methods, to load shader
and texture data using XML http requests, and to create WebGL shader and
texture objects from them:
*/

class Utils {

  static loadShaderSource(shaderName, callback) {
    const xhr = new XMLHttpRequest();
    xhr.open('GET', shaderName);
    xhr.responseType = 'text';
    xhr.onload = (event) => callback(xhr.responseText.trim());
    xhr.send();
  }

  static createShader(gl, type, source) {
    const shader = gl.createShader(type);
    gl.shaderSource(shader, source);
    gl.compileShader(shader);
    return shader;
  }

  static loadTextureData(textureName, callback) {
    const xhr = new XMLHttpRequest();
    xhr.open('GET', textureName);
    xhr.responseType = 'arraybuffer';
    xhr.onload = (event) => {
      const data = new DataView(xhr.response);
      const array =
          new Float32Array(data.byteLength / Float32Array.BYTES_PER_ELEMENT);
      for (var i = 0; i < array.length; ++i) {
        array[i] = data.getFloat32(i * Float32Array.BYTES_PER_ELEMENT, true);
      }
      callback(array);
    };
    xhr.send();
  }

  static createTexture(gl, textureUnit, target) {
    const texture = gl.createTexture();
    gl.activeTexture(textureUnit);
    gl.bindTexture(target, texture);
    gl.texParameteri(target, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
    gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
    gl.texParameteri(target, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
    gl.texParameteri(target, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
    return texture;
  }
}
 109  atmosphere/demo/webgl/precompute.cc 
@@ -0,0 +1,109 @@
/**
 * Copyright (c) 2018 Eric Bruneton
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
 * are met:
 * 1. Redistributions of source code must retain the above copyright
 *    notice, this list of conditions and the following disclaimer.
 * 2. Redistributions in binary form must reproduce the above copyright
 *    notice, this list of conditions and the following disclaimer in the
 *    documentation and/or other materials provided with the distribution.
 * 3. Neither the name of the copyright holders nor the names of its
 *    contributors may be used to endorse or promote products derived from
 *    this software without specific prior written permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 * THE POSSIBILITY OF SUCH DAMAGE.
 */

/*<h2>atmosphere/demo/webgl/precompute.cc</h2>
<p>This file precomputes the atmosphere textures and saves them to disk. It also
saves to disk the shaders necessary for the demo. For this a C++
<a href="../demo.h.html">Demo</a> instance is created (which precomputes the
textures and creates the shaders), its shaders and textures are read back using
the OpenGL API, and are saved to disk:
*/

#include <glad/glad.h>
#include <GL/freeglut.h>

#include <memory>
#include <fstream>

#include "atmosphere/demo/demo.h"
#include "atmosphere/constants.h"

using atmosphere::demo::Demo;

void SaveShader(const GLuint shader, const std::string& filename) {
  GLint sourceLength;
  glGetShaderiv(shader, GL_SHADER_SOURCE_LENGTH, &sourceLength);

  GLsizei actualLength;
  std::unique_ptr<GLchar[]> buffer(new GLchar[sourceLength]);
  glGetShaderSource(shader, sourceLength, &actualLength, buffer.get());

  std::ofstream output_stream(filename, std::ofstream::out);
  output_stream << std::string(buffer.get());
  output_stream.close();
}

void SaveTexture(const GLenum texture_unit, const GLenum texture_target,
    const int texture_size, const std::string& filename) {
  std::unique_ptr<float[]> pixels(new float[texture_size * 4]);
  glActiveTexture(texture_unit);
  glGetTexImage(texture_target, 0, GL_RGBA, GL_FLOAT, pixels.get());

  std::ofstream output_stream(
      filename, std::ofstream::out | std::ofstream::binary);
  output_stream.write((const char*) pixels.get(), texture_size * 16);
  output_stream.close();
}

int main(int argc, char** argv) {
  glutInitContextVersion(3, 3);
  glutInitContextProfile(GLUT_CORE_PROFILE);
  glutInit(&argc, argv);
  glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE);

  std::unique_ptr<Demo> demo(new Demo(0, 0));
  demo->model().SetProgramUniforms(demo->program(), 0, 1, 2);

  const std::string output_dir(argv[1]);
  SaveShader(demo->model().shader(), output_dir + "atmosphere_shader.txt");
  SaveShader(demo->vertex_shader(), output_dir + "vertex_shader.txt");
  SaveShader(demo->fragment_shader(), output_dir + "fragment_shader.txt");
  SaveTexture(
      GL_TEXTURE0,
      GL_TEXTURE_2D,
      atmosphere::TRANSMITTANCE_TEXTURE_WIDTH *
          atmosphere::TRANSMITTANCE_TEXTURE_HEIGHT,
      output_dir + "transmittance.dat");
  SaveTexture(
      GL_TEXTURE1,
      GL_TEXTURE_3D,
      atmosphere::SCATTERING_TEXTURE_WIDTH *
          atmosphere::SCATTERING_TEXTURE_HEIGHT *
          atmosphere::SCATTERING_TEXTURE_DEPTH,
      output_dir + "scattering.dat");
  SaveTexture(
      GL_TEXTURE2,
      GL_TEXTURE_2D,
      atmosphere::IRRADIANCE_TEXTURE_WIDTH *
          atmosphere::IRRADIANCE_TEXTURE_HEIGHT,
      output_dir + "irradiance.dat");

  return 0;
}
 22  atmosphere/model.cc 
@@ -982,11 +982,11 @@ texture units.
*/	*/


void Model::SetProgramUniforms(	void Model::SetProgramUniforms(
    unsigned int program,	    GLuint program,
    unsigned int transmittance_texture_unit,	    GLuint transmittance_texture_unit,
    unsigned int scattering_texture_unit,	    GLuint scattering_texture_unit,
    unsigned int irradiance_texture_unit,	    GLuint irradiance_texture_unit,
    unsigned int single_mie_scattering_texture_unit) const {	    GLuint single_mie_scattering_texture_unit) const {
  glActiveTexture(GL_TEXTURE0 + transmittance_texture_unit);	  glActiveTexture(GL_TEXTURE0 + transmittance_texture_unit);
  glBindTexture(GL_TEXTURE_2D, transmittance_texture_);	  glBindTexture(GL_TEXTURE_2D, transmittance_texture_);
  glUniform1i(glGetUniformLocation(program, "transmittance_texture"),	  glUniform1i(glGetUniformLocation(program, "transmittance_texture"),
@@ -1046,12 +1046,12 @@ described in Algorithm 4.1 of
explained by the inline comments below.	explained by the inline comments below.
*/	*/
void Model::Precompute(	void Model::Precompute(
    unsigned int fbo,	    GLuint fbo,
    unsigned int delta_irradiance_texture,	    GLuint delta_irradiance_texture,
    unsigned int delta_rayleigh_scattering_texture,	    GLuint delta_rayleigh_scattering_texture,
    unsigned int delta_mie_scattering_texture,	    GLuint delta_mie_scattering_texture,
    unsigned int delta_scattering_density_texture,	    GLuint delta_scattering_density_texture,
    unsigned int delta_multiple_scattering_texture,	    GLuint delta_multiple_scattering_texture,
    const vec3& lambdas,	    const vec3& lambdas,
    const mat3& luminance_from_radiance,	    const mat3& luminance_from_radiance,
    bool blend,	    bool blend,
 34  atmosphere/model.h 
@@ -284,14 +284,14 @@ class Model {


  void Init(unsigned int num_scattering_orders = 4);	  void Init(unsigned int num_scattering_orders = 4);


  unsigned int GetShader() const { return atmosphere_shader_; }	  GLuint shader() const { return atmosphere_shader_; }


  void SetProgramUniforms(	  void SetProgramUniforms(
      unsigned int program,	      GLuint program,
      unsigned int transmittance_texture_unit,	      GLuint transmittance_texture_unit,
      unsigned int scattering_texture_unit,	      GLuint scattering_texture_unit,
      unsigned int irradiance_texture_unit,	      GLuint irradiance_texture_unit,
      unsigned int optional_single_mie_scattering_texture_unit = 0) const;	      GLuint optional_single_mie_scattering_texture_unit = 0) const;


  // Utility method to convert a function of the wavelength to linear sRGB.	  // Utility method to convert a function of the wavelength to linear sRGB.
  // 'wavelengths' and 'spectrum' must have the same size. The integral of	  // 'wavelengths' and 'spectrum' must have the same size. The integral of
@@ -312,12 +312,12 @@ class Model {
  typedef std::array<float, 9> mat3;	  typedef std::array<float, 9> mat3;


  void Precompute(	  void Precompute(
      unsigned int fbo,	      GLuint fbo,
      unsigned int delta_irradiance_texture,	      GLuint delta_irradiance_texture,
      unsigned int delta_rayleigh_scattering_texture,	      GLuint delta_rayleigh_scattering_texture,
      unsigned int delta_mie_scattering_texture,	      GLuint delta_mie_scattering_texture,
      unsigned int delta_scattering_density_texture,	      GLuint delta_scattering_density_texture,
      unsigned int delta_multiple_scattering_texture,	      GLuint delta_multiple_scattering_texture,
      const vec3& lambdas,	      const vec3& lambdas,
      const mat3& luminance_from_radiance,	      const mat3& luminance_from_radiance,
      bool blend,	      bool blend,
@@ -327,11 +327,11 @@ class Model {
  bool half_precision_;	  bool half_precision_;
  bool rgb_format_supported_;	  bool rgb_format_supported_;
  std::function<std::string(const vec3&)> glsl_header_factory_;	  std::function<std::string(const vec3&)> glsl_header_factory_;
  unsigned int transmittance_texture_;	  GLuint transmittance_texture_;
  unsigned int scattering_texture_;	  GLuint scattering_texture_;
  unsigned int optional_single_mie_scattering_texture_;	  GLuint optional_single_mie_scattering_texture_;
  unsigned int irradiance_texture_;	  GLuint irradiance_texture_;
  unsigned int atmosphere_shader_;	  GLuint atmosphere_shader_;
  GLuint full_screen_quad_vao_;	  GLuint full_screen_quad_vao_;
  GLuint full_screen_quad_vbo_;	  GLuint full_screen_quad_vbo_;
};	};
 4  atmosphere/reference/model_test.cc 
@@ -525,11 +525,11 @@ we must first initialize the GPU shader, which can be done with the following
    program_ = glCreateProgram();	    program_ = glCreateProgram();
    glAttachShader(program_, vertex_shader);	    glAttachShader(program_, vertex_shader);
    glAttachShader(program_, fragment_shader);	    glAttachShader(program_, fragment_shader);
    glAttachShader(program_, model_->GetShader());	    glAttachShader(program_, model_->shader());
    glLinkProgram(program_);	    glLinkProgram(program_);
    glDetachShader(program_, vertex_shader);	    glDetachShader(program_, vertex_shader);
    glDetachShader(program_, fragment_shader);	    glDetachShader(program_, fragment_shader);
    glDetachShader(program_, model_->GetShader());	    glDetachShader(program_, model_->shader());
    glDeleteShader(vertex_shader);	    glDeleteShader(vertex_shader);
    glDeleteShader(fragment_shader);	    glDeleteShader(fragment_shader);


 12  index 
@@ -90,7 +90,8 @@ its structure and its documentation and give more details about its tests.
implementation</a> can be used in C++ / OpenGL applications as explained	implementation</a> can be used in C++ / OpenGL applications as explained
in <a href="atmosphere/model.h.html">model.h</a>, and as demonstrated in the	in <a href="atmosphere/model.h.html">model.h</a>, and as demonstrated in the
demo in <code>atmosphere/demo</code>. To run this demo, simply type <code>make	demo in <code>atmosphere/demo</code>. To run this demo, simply type <code>make
demo</code> in the main directory.	demo</code> in the main directory. A WebGL2 version of this demo is also
available <a href="demo.html">online</a>.


<p>The default settings of this demo use the real solar spectrum, with an ozone	<p>The default settings of this demo use the real solar spectrum, with an ozone
layer. To simulate the settings of the original implementation, set the solar	layer. To simulate the settings of the original implementation, set the solar
@@ -123,7 +124,8 @@ atmosphere model on GPU.
<ul>	<ul>
  <li>The <code>atmosphere/demo</code> directory shows how the API provided in	  <li>The <code>atmosphere/demo</code> directory shows how the API provided in
     <code>atmosphere</code> can be used in practice, using a small C++/OpenGL	     <code>atmosphere</code> can be used in practice, using a small C++/OpenGL
     demo application.	     demo application. A WebGL2 version of this demo is also available, in the
    <code>webgl</code> subdirectory.
  </li>	  </li>
  <li>The <code>atmosphere/reference</code> directory provides a way to execute	  <li>The <code>atmosphere/reference</code> directory provides a way to execute
    our GLSL code on CPU. Its main purpose is to provide unit tests for the GLSL	    our GLSL code on CPU. Its main purpose is to provide unit tests for the GLSL
@@ -152,6 +154,12 @@ extensive comments in each source code file:
      <li><a href="atmosphere/demo/demo.cc.html">demo.cc</a></li>	      <li><a href="atmosphere/demo/demo.cc.html">demo.cc</a></li>
      <li><a href="atmosphere/demo/demo.glsl.html">demo.glsl</a></li>	      <li><a href="atmosphere/demo/demo.glsl.html">demo.glsl</a></li>
      <li><a href="atmosphere/demo/demo_main.cc.html">demo_main.cc</a></li>	      <li><a href="atmosphere/demo/demo_main.cc.html">demo_main.cc</a></li>
      <li>webgl<ul>
        <li><a href="atmosphere/demo/webgl/demo.js.html">demo.js</a></li>
        <li>
          <a href="atmosphere/demo/webgl/precompute.cc.html">precompute.cc</a>
        </li>
      </ul></li>
    </ul></li>	    </ul></li>
    <li>reference<ul>	    <li>reference<ul>
      <li><a href="atmosphere/reference/definitions.h.html">	      <li><a href="atmosphere/reference/definitions.h.html">
 37  precomputed_atmopheric_scattering.cbp 
@@ -55,6 +55,17 @@
					<Add option="-g" />						<Add option="-g" />
				</Compiler>					</Compiler>
			</Target>				</Target>
			<Target title="Webgl">
				<Option output="output/Webgl/precompute" prefix_auto="1" extension_auto="1" />
				<Option object_output="output/Webgl/" />
				<Option type="1" />
				<Option compiler="gcc" />
				<Compiler>
					<Add option="-fexpensive-optimizations" />
					<Add option="-O3" />
					<Add option="-DNDEBUG" />
				</Compiler>
			</Target>
		</Build>			</Build>
		<Compiler>			<Compiler>
			<Add option="-Wmain" />				<Add option="-Wmain" />
@@ -76,46 +87,63 @@
		<Unit filename="atmosphere/constants.h">			<Unit filename="atmosphere/constants.h">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/definitions.glsl">			<Unit filename="atmosphere/definitions.glsl">
			<Option compile="1" />				<Option compile="1" />
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/demo/demo.cc">			<Unit filename="atmosphere/demo/demo.cc">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/demo/demo.glsl">			<Unit filename="atmosphere/demo/demo.glsl">
			<Option compile="1" />				<Option compile="1" />
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/demo/demo.h">			<Unit filename="atmosphere/demo/demo.h">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/demo/demo_main.cc">			<Unit filename="atmosphere/demo/demo_main.cc">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/demo/webgl/demo.html">
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/webgl/demo.js">
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/webgl/precompute.cc">
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/functions.glsl">			<Unit filename="atmosphere/functions.glsl">
			<Option compile="1" />				<Option compile="1" />
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Test" />				<Option target="Test" />
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/model.cc">			<Unit filename="atmosphere/model.cc">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/model.h">			<Unit filename="atmosphere/model.h">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="atmosphere/reference/definitions.h">			<Unit filename="atmosphere/reference/definitions.h">
			<Option target="Test" />				<Option target="Test" />
@@ -189,11 +217,13 @@
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="external/glad/src/glad.cc">			<Unit filename="external/glad/src/glad.cc">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="external/minpng/minpng.h">			<Unit filename="external/minpng/minpng.h">
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
@@ -204,18 +234,23 @@
		<Unit filename="external/progress_bar/util/progress_bar.h">			<Unit filename="external/progress_bar/util/progress_bar.h">
			<Option target="IntegrationTest" />				<Option target="IntegrationTest" />
		</Unit>			</Unit>
		<Unit filename="index" />			<Unit filename="index">
			<Option target="Docgen" />
		</Unit>
		<Unit filename="text/font.inc">			<Unit filename="text/font.inc">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="text/text_renderer.cc">			<Unit filename="text/text_renderer.cc">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="text/text_renderer.h">			<Unit filename="text/text_renderer.h">
			<Option target="Debug" />				<Option target="Debug" />
			<Option target="Release" />				<Option target="Release" />
			<Option target="Webgl" />
		</Unit>			</Unit>
		<Unit filename="tools/docgen_main.cc">			<Unit filename="tools/docgen_main.cc">
			<Option target="Docgen" />				<Option target="Docgen" />
              u_atm_p[10] * cos_gamma2)) * u_atm_p[11];
    xyy.z = a_luminance;

    // Ad-hoc tuning. Scaling before the blue shift allows to obtain proper
    // blueish colors at sun set instead of very red, which is a shortcoming
    // of preetham model.
    xyy.z *= 0.08;

    // Convert this sky luminance/chromaticity into perceived color using model
    // from Henrik Wann Jensen (2000)
    // We deal with 3 cases:
    //  * Y <= 0.01: scotopic vision. Only the eyes' rods see. No colors,
    //    everything is converted to night blue (xy = 0.25, 0.25)
    //  * Y > 3.981: photopic vision. Only the eyes's cones seew ith full colors
    //  * Y > 0.01 and Y <= 3.981: mesopic vision. Rods and cones see in a
    //    transition state.
    //
    // Compute s, ratio between scotopic and photopic vision
    highp float op = (log(xyy.z) / log(10.) + 2.) / 2.6;
    highp float s = (xyy.z <= 0.01) ? 0.0 : (xyy.z > 3.981) ? 1.0 : op * op * (3. - 2. * op);

    // Perform the blue shift on chromaticity
    xyy.x = mix(0.25, xyy.x, s);
    xyy.y = mix(0.25, xyy.y, s);
    // Scale scotopic luminance for scotopic pixels
    xyy.z = 0.4468 * (1. - s) * xyy.z + s * xyy.z;

    // Apply logarithmic tonemapping on luminance Y only.
    // Code should be the same as in tonemapper.c, assuming q == 1.
    xyy.z = log(1.0 + xyy.z * u_tm[0]) / log(1.0 + u_tm[1] * u_tm[0]) * u_tm[2];

    // Convert xyY to sRGB
    highp vec3 rgb = xyy_to_srgb(xyy);

    // Apply gamma correction
    v_color = vec4(gammaf(rgb.r), gammaf(rgb.g),gammaf(rgb.b), 1.0);
}

#endif
#ifdef FRAGMENT_SHADER

void main()
{
    gl_FragColor = v_color;
}

#endif