### PR TITLE
Patch 2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -218,7 +218,8 @@ if target_os == 'js':
         ]
 
     if debug:
-        flags += ['-s', 'SAFE_HEAP=1', '-s', 'ASSERTIONS=1']
+        flags += ['-s', 'SAFE_HEAP=1', '-s', 'ASSERTIONS=1',
+                  '-s', 'WARN_UNALIGNED=1']
 
     if es6:
         flags += ['-s', 'EXPORT_ES6=1']

--- a/data/shaders/atmosphere.glsl
+++ b/data/shaders/atmosphere.glsl
@@ -83,7 +83,15 @@ void main()
     // Compute s, ratio between scotopic and photopic vision
     highp float op = (log(xyy.z) / log(10.) + 2.) / 2.6;
     highp float s = (xyy.z <= 0.01) ? 0.0 : (xyy.z > 3.981) ? 1.0 : op * op * (3. - 2. * op);
-
+@@ -89,7 +89,7 @@ void SaveTexture(const GLenum texture_unit, const GLenum texture_target,
+  {
+      using namespace atmosphere;
+      const std::int32_t header[]={SCATTERING_TEXTURE_MU_S_SIZE, SCATTERING_TEXTURE_MU_SIZE,
+                                   SCATTERING_TEXTURE_R_SIZE, SCATTERING_TEXTURE_NU_SIZE,
+                                   SCATTERING_TEXTURE_NU_SIZE, SCATTERING_TEXTURE_R_SIZE,
+                                   4};
+      output_stream.write(reinterpret_cast<const char*>(header), sizeof header);
+  }
     // Perform the blue shift on chromaticity
     xyy.x = mix(0.25, xyy.x, s);
     xyy.y = mix(0.25, xyy.y, s);

--- a/src/modules/constellations.c
+++ b/src/modules/constellations.c
@@ -73,6 +73,7 @@ typedef struct constellations {
     fader_t     labels_visible;
     bool        show_all;
     int         labels_display_style;
+    bool        lines_animation;
 } constellations_t;
 
 static int constellation_update(constellation_t *con, const observer_t *obs);
@@ -585,7 +586,8 @@ static int render_lines(constellation_t *con, const painter_t *_painter,
         // Add some space, using ad-hoc formula.
         line_truncate(&lines[i], radius[0] * 1.0 + 0.2 * DD2R,
                                  radius[1] * 1.0 + 0.2 * DD2R);
-        line_animation_effect(&lines[i], visible * 2);
+        if (cons->lines_animation)
+            line_animation_effect(&lines[i], visible * 2);
     }
 
     for (i = 0; i < con->count; i += 2) {
@@ -773,6 +775,7 @@ static int constellations_init(obj_t *obj, json_value *args)
 {
     constellations_t *conss = (void*)obj;
     conss->show_all = true;
+    conss->lines_animation = true;
     fader_init(&conss->visible, true);
     fader_init(&conss->lines_visible, false);
     fader_init(&conss->labels_visible, false);
@@ -894,6 +897,8 @@ static obj_klass_t constellations_klass = {
         PROPERTY(show_all, TYPE_BOOL, MEMBER(constellations_t, show_all)),
         PROPERTY(labels_display_style, TYPE_ENUM,
                  MEMBER(constellations_t, labels_display_style)),
+        PROPERTY(lines_animation TYPE_BOOL,
+                 MEMBER(constellations_t, lines_animation)),
         {}
     },
 };

--- a/src/utils/request_js.c
+++ b/src/utils/request_js.c
@@ -107,7 +107,7 @@ static void onload(unsigned int _, void *arg, void *data, unsigned int size)
 static void onerror(unsigned int _, void *arg, int err, const char *msg)
 {
     request_t *req = arg;
-    LOG_D("onerror %s %d %s", req->url, err, msg);
+    // LOG_D("onerror %s %d %s", req->url, err, msg);
     req->handle = 0;
     // Use a default error code if we didn't get one...
     req->status_code = err ?: 499;

--- a/web-frontend/src/components/location-mgr.vue
+++ b/web-frontend/src/components/location-mgr.vue
@@ -117,7 +117,9 @@ export default {
     this.$nextTick(() => {
       let map = this.$refs.myMap.mapObject
       var geocoder = new L.Control.Geocoder({
-        defaultMarkGeocode: false, position: 'topleft'
+        defaultMarkGeocode: false,
+        position: 'topleft',
+        collapsed: false
       }).on('markgeocode', function (e) {
         var pos = { lat: e.geocode.center.lat, lng: e.geocode.center.lng }
         that.mapCenter = [ pos.lat, pos.lng ]
@@ -141,6 +143,7 @@ export default {
         }
         that.pickLocation = loc
         that.setPickLocationMode()
+        geocoder.setQuery('')
       })
       geocoder.addTo(map)
     })


### PR DESCRIPTION
@@ -38,9 +38,10 @@ DIRS := atmosphere text tools
HEADERS := $(shell find $(DIRS) -name "*.h")
SOURCES := $(shell find $(DIRS) -name "*.cc")
GLSL_SOURCES := $(shell find $(DIRS) -name "*.glsl")
DOC_SOURCES := $(HEADERS) $(SOURCES) $(GLSL_SOURCES) index
JS_SOURCES := $(shell find $(DIRS) -name "*.js")
DOC_SOURCES := $(HEADERS) $(SOURCES) $(GLSL_SOURCES) $(JS_SOURCES) index

all: lint doc test integration_test demo
all: lint doc test integration_test webgl demo

# cpplint can be installed with "pip install cpplint".
# We exclude runtime/references checking for functions.h and model_test.cc
@@ -66,6 +67,8 @@ integration_test: output/Release/atmosphere_integration_test
	mkdir -p output/Doc/atmosphere/reference
	output/Release/atmosphere_integration_test

webgl: output/Doc/scattering.dat output/Doc/demo.html output/Doc/demo.js

demo: output/Debug/atmosphere_demo
	output/Debug/atmosphere_demo

@@ -77,6 +80,18 @@ output/Doc/%.html: % output/Debug/tools/docgen tools/docgen_template.html
	mkdir -p $(@D)
	output/Debug/tools/docgen $< tools/docgen_template.html $@

output/Doc/scattering.dat: output/Debug/precompute
	mkdir -p $(@D)
	output/Debug/precompute $(@D)/

output/Doc/demo.html: atmosphere/demo/webgl/demo.html
	mkdir -p $(@D)
	cp $< $@

output/Doc/demo.js: atmosphere/demo/webgl/demo.js
	mkdir -p $(@D)
	cp $< $@

output/Debug/tools/docgen: output/Debug/tools/docgen_main.o
	$(GPP) $< -o $@

@@ -96,6 +111,14 @@ output/Release/atmosphere_integration_test: \
    output/Release/external/progress_bar/util/progress_bar.o
	$(GPP) $^ -pthread -ldl -lglut -lGL -o $@

output/Debug/precompute: \
    output/Debug/atmosphere/demo/demo.o \
    output/Debug/atmosphere/demo/webgl/precompute.o \
    output/Debug/atmosphere/model.o \
    output/Debug/text/text_renderer.o \
    output/Debug/external/glad/src/glad.o
	$(GPP) $^ -pthread -ldl -lglut -lGL -o $@

output/Debug/atmosphere_demo: \
    output/Debug/atmosphere/demo/demo.o \
    output/Debug/atmosphere/demo/demo_main.o \@@ -170,6 +170,8 @@ Demo::Demo(int viewport_width, int viewport_height) :
*/

Demo::~Demo() {
  glDeleteShader(vertex_shader_);
  glDeleteShader(fragment_shader_);
  glDeleteProgram(program_);
  glDeleteBuffers(1, &full_screen_quad_vbo_);
  glDeleteVertexArrays(1, &full_screen_quad_vao_);
@@ -287,10 +289,10 @@ our demo scene, and link them with the <code>Model</code>'s atmosphere shader
to get the final scene rendering program:
*/

  GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
  vertex_shader_ = glCreateShader(GL_VERTEX_SHADER);
  const char* const vertex_shader_source = kVertexShader;
  glShaderSource(vertex_shader, 1, &vertex_shader_source, NULL);
  glCompileShader(vertex_shader);
  glShaderSource(vertex_shader_, 1, &vertex_shader_source, NULL);
  glCompileShader(vertex_shader_);

  const std::string fragment_shader_str =
      "#version 330\n" +
@@ -299,23 +301,21 @@ to get the final scene rendering program:
      std::to_string(kLengthUnitInMeters) + ";\n" +
      demo_glsl;
  const char* fragment_shader_source = fragment_shader_str.c_str();
  GLuint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
  glShaderSource(fragment_shader, 1, &fragment_shader_source, NULL);
  glCompileShader(fragment_shader);
  fragment_shader_ = glCreateShader(GL_FRAGMENT_SHADER);
  glShaderSource(fragment_shader_, 1, &fragment_shader_source, NULL);
  glCompileShader(fragment_shader_);

  if (program_ != 0) {
    glDeleteProgram(program_);
  }
  program_ = glCreateProgram();
  glAttachShader(program_, vertex_shader);
  glAttachShader(program_, fragment_shader);
  glAttachShader(program_, model_->GetShader());
  glAttachShader(program_, vertex_shader_);
  glAttachShader(program_, fragment_shader_);
  glAttachShader(program_, model_->shader());
  glLinkProgram(program_);
  glDetachShader(program_, vertex_shader);
  glDetachShader(program_, fragment_shader);
  glDetachShader(program_, model_->GetShader());
  glDeleteShader(vertex_shader);
  glDeleteShader(fragment_shader);
  glDetachShader(program_, vertex_shader_);
  glDetachShader(program_, fragment_shader_);
  glDetachShader(program_, model_->shader());

/*
<p>Finally, it sets the uniforms of this program that can be set once and for @@ -47,7 +47,7 @@ uniform vec3 earth_center;
uniform vec3 sun_direction;
uniform vec2 sun_size;
in vec3 view_ray;
layout(location = 0) out vec3 color;
layout(location = 0) out vec4 color;

/*
<p>It uses the following constants, as well as the following atmosphere
@@ -381,6 +381,7 @@ the scene:
  }
  radiance = mix(radiance, ground_radiance, ground_alpha);
  radiance = mix(radiance, sphere_radiance, sphere_alpha);
  color =
     pow(vec3(1.0) - exp(-radiance / white_point * exposure), vec3(1.0 / 2.2));
  color.rgb = 
      pow(vec3(1.0) - exp(-radiance / white_point * exposure), vec3(1.0 / 2.2));
  color.a = 1.0;
}@@ -55,6 +55,11 @@ class Demo {
  Demo(int viewport_width, int viewport_height);
  ~Demo();

  const Model& model() const { return *model_; }
  const GLuint vertex_shader() const { return vertex_shader_; }
  const GLuint fragment_shader() const { return fragment_shader_; }
  const GLuint program() const { return program_; }

 private:
  enum Luminance {
    // Render the spectral radiance at kLambdaR, kLambdaG, kLambdaB.
@@ -91,7 +96,9 @@ class Demo {
  bool show_help_;

  std::unique_ptr<Model> model_;
  unsigned int program_;
  GLuint vertex_shader_;
  GLuint fragment_shader_;
  GLuint program_;
  GLuint full_screen_quad_vao_;
  GLuint full_screen_quad_vbo_;
  std::unique_ptr<TextRenderer> text_renderer_; @@ -0,0 +1,51 @@
<html>
  <head>
    <meta charset="utf-8">
    <title>Precomputed Atmospheric Scattering - WebGL Demo</title>
    <script type="text/javascript" src="demo.js"></script>
    <style>
      html, body {
        position: relative;
        width: 100%;
        height: 100%;
        padding: 0;
        margin: 0;
        overflow: hidden;
      }
      #help {
        position: absolute;
        top: 0;
        left: 0;
        color: red;
        font-family: monospace;
      }
      ul {
        padding-left: 1em;
      }
      li {
        list-style: none;
      }
    </style>
  </head>
  <body onload="new Demo(document.body);">
    <canvas id="glcanvas" width="400" height="300"></canvas>
    <ul id="help">
      <li>
        <a href="index.html">Precomputed Atmospheric Scattering - WebGL Demo</a>
      </li>
      <li>&nbsp;</li>
      <li>Mouse:
        <ul>
          <li>drag, CTRL+drag, wheel: view and sun directions</li>
        </ul>
      </li>
      <li>Keys:
        <ul>
          <li>h: help</li>
          <li>+/-: increase/decrease exposure</li>
          <li>1-9: predefined views</li>
        </ul>
      </li>
    </ul>
  </body>
</html> @@ -0,0 +1,387 @@
/**
 * Copyright (c) 2018 Eric Bruneton
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
 * are met:
 * 1. Redistributions of source code must retain the above copyright
 *    notice, this list of conditions and the following disclaimer.
 * 2. Redistributions in binary form must reproduce the above copyright
 *    notice, this list of conditions and the following disclaimer in the
 *    documentation and/or other materials provided with the distribution.
 * 3. Neither the name of the copyright holders nor the names of its
 *    contributors may be used to endorse or promote products derived from
 *    this software without specific prior written permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 * THE POSSIBILITY OF SUCH DAMAGE.
 */

/*<h2>atmosphere/demo/webgl/demo.js</h2>
<p>This file is a Javascript transcription of the original
<a href="../demo.cc.html">C++</a> code of the demo, where the code related to
the atmosphere model initialisation is replaced with code to load precomputed
textures and shaders from the network (those are precomputed with
<a href="precompute.cc.html">precompute.cc</a>).
<p>The following constants must have the same values as in
<a href="../../constants.h.html">constants.h</a> and
<a href="../demo.cc.html">demo.cc</a>:
*/

const TRANSMITTANCE_TEXTURE_WIDTH = 256;
const TRANSMITTANCE_TEXTURE_HEIGHT = 64;
const SCATTERING_TEXTURE_WIDTH = 256;
const SCATTERING_TEXTURE_HEIGHT = 128;
const SCATTERING_TEXTURE_DEPTH = 32;
const IRRADIANCE_TEXTURE_WIDTH = 64;
const IRRADIANCE_TEXTURE_HEIGHT = 16;

const kSunAngularRadius = 0.00935 / 2;
const kSunSolidAngle = Math.PI * kSunAngularRadius * kSunAngularRadius;
const kLengthUnitInMeters = 1000;

/*
<p>As in the C++ version, the code consists in a single class. Its constructor
initializes the WebGL canvas, declares the fields of the class, sets up the
event handlers and starts the resource loading and the render loop:
*/

class Demo {
  constructor(rootElement) {
    this.canvas = rootElement.querySelector('#glcanvas');
    this.canvas.style.width = `${rootElement.clientWidth}px`;
    this.canvas.style.height = `${rootElement.clientHeight}px`;
    this.canvas.width = rootElement.clientWidth * window.devicePixelRatio;
    this.canvas.height = rootElement.clientHeight * window.devicePixelRatio;
    this.help = rootElement.querySelector('#help');
    this.gl = this.canvas.getContext('webgl2');

    this.vertexBuffer = null;
    this.transmittanceTexture = null;
    this.scatteringTexture = null;
    this.irradianceTexture = null;
    this.vertexShaderSource = null;
    this.fragmentShaderSource = null;
    this.atmosphereShaderSource = null;
    this.program = null;

    this.viewFromClip = new Float32Array(16);
    this.modelFromView = new Float32Array(16);
    this.viewDistanceMeters = 9000;
    this.viewZenithAngleRadians = 1.47;
    this.viewAzimuthAngleRadians = -0.1;
    this.sunZenithAngleRadians = 1.3;
    this.sunAzimuthAngleRadians = 2.9;
    this.exposure = 10;

    this.drag = undefined;
    this.previousMouseX = undefined;
    this.previousMouseY = undefined;

    rootElement.addEventListener('keypress', (e) => this.onKeyPress(e));
    rootElement.addEventListener('mousedown', (e) => this.onMouseDown(e));
    rootElement.addEventListener('mousemove', (e) => this.onMouseMove(e));
    rootElement.addEventListener('mouseup', (e) => this.onMouseUp(e));
    rootElement.addEventListener('wheel', (e) => this.onMouseWheel(e));

    this.init();
    requestAnimationFrame(() => this.onRender());
  }

/*
<p>The init method creates a vertex buffer for a full screen quad, and loads the
precomputed textures and the shaders for the demo (using utility methods defined
in the <code>Utils</code> class below):
*/

  init() {
    const gl = this.gl;
    this.vertexBuffer = gl.createBuffer();
    gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer);
    gl.bufferData(gl.ARRAY_BUFFER,
       new Float32Array([-1, -1, +1, -1, -1, +1, +1, +1]), gl.STATIC_DRAW);

    Utils.loadTextureData('transmittance.dat', (data) => {
      this.transmittanceTexture =
          Utils.createTexture(gl, gl.TEXTURE0, gl.TEXTURE_2D);
      gl.texImage2D(gl.TEXTURE_2D, 0,
          gl.getExtension('OES_texture_float_linear') ? gl.RGBA32F : gl.RGBA16F,
          TRANSMITTANCE_TEXTURE_WIDTH, TRANSMITTANCE_TEXTURE_HEIGHT, 0, gl.RGBA,
          gl.FLOAT, data);
    });
    Utils.loadTextureData('scattering.dat', (data) => {
      this.scatteringTexture =
          Utils.createTexture(gl, gl.TEXTURE1, gl.TEXTURE_3D);
      gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE);
      gl.texImage3D(gl.TEXTURE_3D, 0, gl.RGBA16F, SCATTERING_TEXTURE_WIDTH,
          SCATTERING_TEXTURE_HEIGHT, SCATTERING_TEXTURE_DEPTH, 0, gl.RGBA,
          gl.FLOAT, data);
    });
    Utils.loadTextureData('irradiance.dat', (data) => {
      this.irradianceTexture =
          Utils.createTexture(gl, gl.TEXTURE2, gl.TEXTURE_2D);
      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA16F, IRRADIANCE_TEXTURE_WIDTH,
          IRRADIANCE_TEXTURE_HEIGHT, 0, gl.RGBA, gl.FLOAT, data);
    });

    Utils.loadShaderSource('vertex_shader.txt', (source) => {
      this.vertexShaderSource = source;
    });
    Utils.loadShaderSource('fragment_shader.txt', (source) => {
      this.fragmentShaderSource = source;
    });
    Utils.loadShaderSource('atmosphere_shader.txt', (source) => {
      this.atmosphereShaderSource = source;
    });
  }

/*
<p>The WebGL program cannot be created before all the shaders are loaded. This
is done in the following method, which is called at each frame (the precomputed
shaders are OpenGL 3.3 shaders, so they must be adapted for WebGL2. In
particular, the version id must be changed, and the fragment shaders must be
concatenated because WebGL2 does not support multiple shaders of the same type):
*/

  maybeInitProgram() {
    if (this.program ||
        !this.vertexShaderSource ||
        !this.fragmentShaderSource ||
        !this.atmosphereShaderSource) {
      return;
    }
    const gl = this.gl;
    const vertexShader =
        Utils.createShader(gl, gl.VERTEX_SHADER,
            this.vertexShaderSource.replace('#version 330', '#version 300 es'));
    const fragmentShader = Utils.createShader(
        gl,
        gl.FRAGMENT_SHADER,
        this.atmosphereShaderSource
            .replace('#version 330',
                     '#version 300 es\n' +
                     'precision highp float;\n' +
                     'precision highp sampler3D;') +
        this.fragmentShaderSource
            .replace('#version 330', '')
            .replace('const float PI = 3.14159265;', '')
        );
    this.program = gl.createProgram();
    gl.attachShader(this.program, vertexShader);
    gl.attachShader(this.program, fragmentShader);
    gl.linkProgram(this.program);
  }

/*
<p>The render loop body sets the program attributes and uniforms, and renders
a full screen quad with it:
*/

  onRender() {
    const gl = this.gl;
    gl.clearColor(0, 0, 0, 1);
    gl.clear(gl.COLOR_BUFFER_BIT);

    this.maybeInitProgram();
    if (!this.program) {
      requestAnimationFrame(() => this.onRender());
      return;
    }

    const kFovY = 50 / 180 * Math.PI;
    const kTanFovY = Math.tan(kFovY / 2);
    const aspectRatio = this.canvas.width / this.canvas.height;
    this.viewFromClip.set([
        kTanFovY * aspectRatio, 0, 0, 0,
        0, kTanFovY, 0, 0,
        0, 0, 0, -1,
        0, 0, 1, 1]);

    const cosZ = Math.cos(this.viewZenithAngleRadians);
    const sinZ = Math.sin(this.viewZenithAngleRadians);
    const cosA = Math.cos(this.viewAzimuthAngleRadians);
    const sinA = Math.sin(this.viewAzimuthAngleRadians);
    const viewDistance = this.viewDistanceMeters / kLengthUnitInMeters;
    this.modelFromView.set([
        -sinA, -cosZ * cosA,  sinZ * cosA, sinZ * cosA * viewDistance,
        cosA, -cosZ * sinA, sinZ * sinA, sinZ * sinA * viewDistance,
        0, sinZ, cosZ, cosZ * viewDistance,
        0, 0, 0, 1]);

    const program = this.program;
    gl.useProgram(program);
    gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer);
    gl.vertexAttribPointer(
        gl.getAttribLocation(program, 'vertex'),
        /*numComponents=*/ 2,
        /*type=*/ this.gl.FLOAT,
        /*normalize=*/ false,
        /*stride=*/ 0,
        /*offset=*/ 0);
    gl.enableVertexAttribArray(gl.getAttribLocation(program, 'vertex'));
    gl.uniformMatrix4fv(gl.getUniformLocation(program, 'view_from_clip'),
        true,  this.viewFromClip);
    gl.uniformMatrix4fv(gl.getUniformLocation(program, 'model_from_view'),
        true,  this.modelFromView);
    gl.uniform1i(gl.getUniformLocation(program, 'transmittance_texture'), 0);
    gl.uniform1i(gl.getUniformLocation(program, 'scattering_texture'), 1);
    gl.uniform1i(gl.getUniformLocation(program, 'irradiance_texture'), 2);
    gl.uniform3f(gl.getUniformLocation(program, 'camera'),
        this.modelFromView[3], this.modelFromView[7], this.modelFromView[11]);
    gl.uniform3f(gl.getUniformLocation(program, 'white_point'), 1, 1, 1);
    gl.uniform1f(gl.getUniformLocation(program, 'exposure'), this.exposure);
    gl.uniform3f(gl.getUniformLocation(program, 'earth_center'),
        0, 0, -6360000 / kLengthUnitInMeters);
    gl.uniform3f(gl.getUniformLocation(program, 'sun_direction'),
        Math.cos(this.sunAzimuthAngleRadians) *
            Math.sin(this.sunZenithAngleRadians),
        Math.sin(this.sunAzimuthAngleRadians) *
            Math.sin(this.sunZenithAngleRadians),
        Math.cos(this.sunZenithAngleRadians));
    gl.uniform2f(gl.getUniformLocation(program, 'sun_size'),
        Math.tan(kSunAngularRadius), Math.cos(kSunAngularRadius));
    gl.drawArrays(gl.TRIANGLE_STRIP, /*offset=*/ 0, /*vertexCount=*/ 4);
    requestAnimationFrame(() => this.onRender());
  }

/*
<p>The last part of the Demo class are the event handler methods, which are
directly adapted from the C++ code:
*/

  onKeyPress(event) {
    const key = event.key;
    if (key == 'h') {
      const hidden = this.help.style.display == 'none';
      this.help.style.display = hidden ? 'block' : 'none';
    } else if (key == '+') {
      this.exposure *= 1.1;
    } else if (key == '-') {
      this.exposure /= 1.1;
    } else if (key == '1') {
      this.setView(9000, 1.47, 0, 1.3, 3, 10);
    } else if (key == '2') {
      this.setView(9000, 1.47, 0, 1.564, -3, 10);
    } else if (key == '3') {
      this.setView(7000, 1.57, 0, 1.54, -2.96, 10);
    } else if (key == '4') {
      this.setView(7000, 1.57, 0, 1.328, -3.044, 10);
    } else if (key == '5') {
      this.setView(9000, 1.39, 0, 1.2, 0.7, 10);
    } else if (key == '6') {
      this.setView(9000, 1.5, 0, 1.628, 1.05, 200);
    } else if (key == '7') {
      this.setView(7000, 1.43, 0, 1.57, 1.34, 40);
    } else if (key == '8') {
      this.setView(2.7e6, 0.81, 0, 1.57, 2, 10);
    } else if (key == '9') {
      this.setView(1.2e7, 0.0, 0, 0.93, -2, 10);
    }
  }

  setView(viewDistanceMeters, viewZenithAngleRadians, viewAzimuthAngleRadians,
      sunZenithAngleRadians, sunAzimuthAngleRadians, exposure) {
    this.viewDistanceMeters = viewDistanceMeters;
    this.viewZenithAngleRadians = viewZenithAngleRadians;
    this.viewAzimuthAngleRadians = viewAzimuthAngleRadians;
    this.sunZenithAngleRadians = sunZenithAngleRadians;
    this.sunAzimuthAngleRadians = sunAzimuthAngleRadians;
    this.exposure = exposure;
  }

  onMouseDown(event) {
    this.previousMouseX = event.offsetX;
    this.previousMouseY = event.offsetY;
    this.drag = event.ctrlKey ? 'sun' : 'camera';
  }

  onMouseMove(event) {
    const kScale = 500;
    const mouseX = event.offsetX;
    const mouseY = event.offsetY;
    if (this.drag == 'sun') {
      this.sunZenithAngleRadians -= (this.previousMouseY - mouseY) / kScale;
      this.sunZenithAngleRadians =
        Math.max(0, Math.min(Math.PI, this.sunZenithAngleRadians));
      this.sunAzimuthAngleRadians += (this.previousMouseX - mouseX) / kScale;
    } else if (this.drag == 'camera') {
      this.viewZenithAngleRadians += (this.previousMouseY - mouseY) / kScale;
      this.viewZenithAngleRadians =
          Math.max(0, Math.min(Math.PI / 2, this.viewZenithAngleRadians));
      this.viewAzimuthAngleRadians += (this.previousMouseX - mouseX) / kScale;
    }
    this.previousMouseX = mouseX;
    this.previousMouseY = mouseY;
  }

  onMouseUp(event) {
    this.drag = undefined;
  }

  onMouseWheel(event) {
    this.viewDistanceMeters *= event.deltaY > 0 ? 1.05 : 1 / 1.05;
  }
}

/*
<p>The <code>Utils</code> class used above provides 4 methods, to load shader
and texture data using XML http requests, and to create WebGL shader and
texture objects from them:
*/

class Utils {

  static loadShaderSource(shaderName, callback) {
    const xhr = new XMLHttpRequest();
    xhr.open('GET', shaderName);
    xhr.responseType = 'text';
    xhr.onload = (event) => callback(xhr.responseText.trim());
    xhr.send();
  }

  static createShader(gl, type, source) {
    const shader = gl.createShader(type);
    gl.shaderSource(shader, source);
    gl.compileShader(shader);
    return shader;
  }

  static loadTextureData(textureName, callback) {
    const xhr = new XMLHttpRequest();
    xhr.open('GET', textureName);
    xhr.responseType = 'arraybuffer';
    xhr.onload = (event) => {
      const data = new DataView(xhr.response);
      const array =
          new Float32Array(data.byteLength / Float32Array.BYTES_PER_ELEMENT);
      for (var i = 0; i < array.length; ++i) {
        array[i] = data.getFloat32(i * Float32Array.BYTES_PER_ELEMENT, true);
      }
      callback(array);
    };
    xhr.send();
  }

  static createTexture(gl, textureUnit, target) {
    const texture = gl.createTexture();
    gl.activeTexture(textureUnit);
    gl.bindTexture(target, texture);
    gl.texParameteri(target, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
    gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
    gl.texParameteri(target, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
    gl.texParameteri(target, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
    return texture;
  }
}@@ -0,0 +1,109 @@
/**
 * Copyright (c) 2018 Eric Bruneton
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
 * are met:
 * 1. Redistributions of source code must retain the above copyright
 *    notice, this list of conditions and the following disclaimer.
 * 2. Redistributions in binary form must reproduce the above copyright
 *    notice, this list of conditions and the following disclaimer in the
 *    documentation and/or other materials provided with the distribution.
 * 3. Neither the name of the copyright holders nor the names of its
 *    contributors may be used to endorse or promote products derived from
 *    this software without specific prior written permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 * THE POSSIBILITY OF SUCH DAMAGE.
 */

/*<h2>atmosphere/demo/webgl/precompute.cc</h2>
<p>This file precomputes the atmosphere textures and saves them to disk. It also
saves to disk the shaders necessary for the demo. For this a C++
<a href="../demo.h.html">Demo</a> instance is created (which precomputes the
textures and creates the shaders), its shaders and textures are read back using
the OpenGL API, and are saved to disk:
*/

#include <glad/glad.h>
#include <GL/freeglut.h>

#include <memory>
#include <fstream>

#include "atmosphere/demo/demo.h"
#include "atmosphere/constants.h"

using atmosphere::demo::Demo;

void SaveShader(const GLuint shader, const std::string& filename) {
  GLint sourceLength;
  glGetShaderiv(shader, GL_SHADER_SOURCE_LENGTH, &sourceLength);

  GLsizei actualLength;
  std::unique_ptr<GLchar[]> buffer(new GLchar[sourceLength]);
  glGetShaderSource(shader, sourceLength, &actualLength, buffer.get());

  std::ofstream output_stream(filename, std::ofstream::out);
  output_stream << std::string(buffer.get());
  output_stream.close();
}

void SaveTexture(const GLenum texture_unit, const GLenum texture_target,
    const int texture_size, const std::string& filename) {
  std::unique_ptr<float[]> pixels(new float[texture_size * 4]);
  glActiveTexture(texture_unit);
  glGetTexImage(texture_target, 0, GL_RGBA, GL_FLOAT, pixels.get());

  std::ofstream output_stream(
      filename, std::ofstream::out | std::ofstream::binary);
  output_stream.write((const char*) pixels.get(), texture_size * 16);
  output_stream.close();
}

int main(int argc, char** argv) {
  glutInitContextVersion(3, 3);
  glutInitContextProfile(GLUT_CORE_PROFILE);
  glutInit(&argc, argv);
  glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE);

  std::unique_ptr<Demo> demo(new Demo(0, 0));
  demo->model().SetProgramUniforms(demo->program(), 0, 1, 2);

  const std::string output_dir(argv[1]);
  SaveShader(demo->model().shader(), output_dir + "atmosphere_shader.txt");
  SaveShader(demo->vertex_shader(), output_dir + "vertex_shader.txt");
  SaveShader(demo->fragment_shader(), output_dir + "fragment_shader.txt");
  SaveTexture(
      GL_TEXTURE0,
      GL_TEXTURE_2D,
      atmosphere::TRANSMITTANCE_TEXTURE_WIDTH *
          atmosphere::TRANSMITTANCE_TEXTURE_HEIGHT,
      output_dir + "transmittance.dat");
  SaveTexture(
      GL_TEXTURE1,
      GL_TEXTURE_3D,
      atmosphere::SCATTERING_TEXTURE_WIDTH *
          atmosphere::SCATTERING_TEXTURE_HEIGHT *
          atmosphere::SCATTERING_TEXTURE_DEPTH,
      output_dir + "scattering.dat");
  SaveTexture(
      GL_TEXTURE2,
      GL_TEXTURE_2D,
      atmosphere::IRRADIANCE_TEXTURE_WIDTH *
          atmosphere::IRRADIANCE_TEXTURE_HEIGHT,
      output_dir + "irradiance.dat");

  return 0;
} @@ -982,11 +982,11 @@ texture units.
*/

void Model::SetProgramUniforms(
    unsigned int program,
    unsigned int transmittance_texture_unit,
    unsigned int scattering_texture_unit,
    unsigned int irradiance_texture_unit,
    unsigned int single_mie_scattering_texture_unit) const {
    GLuint program,
    GLuint transmittance_texture_unit,
    GLuint scattering_texture_unit,
    GLuint irradiance_texture_unit,
    GLuint single_mie_scattering_texture_unit) const {
  glActiveTexture(GL_TEXTURE0 + transmittance_texture_unit);
  glBindTexture(GL_TEXTURE_2D, transmittance_texture_);
  glUniform1i(glGetUniformLocation(program, "transmittance_texture"),
@@ -1046,12 +1046,12 @@ described in Algorithm 4.1 of
explained by the inline comments below.
*/
void Model::Precompute(
    unsigned int fbo,
    unsigned int delta_irradiance_texture,
    unsigned int delta_rayleigh_scattering_texture,
    unsigned int delta_mie_scattering_texture,
    unsigned int delta_scattering_density_texture,
    unsigned int delta_multiple_scattering_texture,
    GLuint fbo,
    GLuint delta_irradiance_texture,
    GLuint delta_rayleigh_scattering_texture,
    GLuint delta_mie_scattering_texture,
    GLuint delta_scattering_density_texture,
    GLuint delta_multiple_scattering_texture,
    const vec3& lambdas,
    const mat3& luminance_from_radiance,
    bool blend, @@ -284,14 +284,14 @@ class Model {

  void Init(unsigned int num_scattering_orders = 4);

  unsigned int GetShader() const { return atmosphere_shader_; }
  GLuint shader() const { return atmosphere_shader_; }

  void SetProgramUniforms(
      unsigned int program,
      unsigned int transmittance_texture_unit,
      unsigned int scattering_texture_unit,
      unsigned int irradiance_texture_unit,
      unsigned int optional_single_mie_scattering_texture_unit = 0) const;
      GLuint program,
      GLuint transmittance_texture_unit,
      GLuint scattering_texture_unit,
      GLuint irradiance_texture_unit,
      GLuint optional_single_mie_scattering_texture_unit = 0) const;

  // Utility method to convert a function of the wavelength to linear sRGB.
  // 'wavelengths' and 'spectrum' must have the same size. The integral of
@@ -312,12 +312,12 @@ class Model {
  typedef std::array<float, 9> mat3;

  void Precompute(
      unsigned int fbo,
      unsigned int delta_irradiance_texture,
      unsigned int delta_rayleigh_scattering_texture,
      unsigned int delta_mie_scattering_texture,
      unsigned int delta_scattering_density_texture,
      unsigned int delta_multiple_scattering_texture,
      GLuint fbo,
      GLuint delta_irradiance_texture,
      GLuint delta_rayleigh_scattering_texture,
      GLuint delta_mie_scattering_texture,
      GLuint delta_scattering_density_texture,
      GLuint delta_multiple_scattering_texture,
      const vec3& lambdas,
      const mat3& luminance_from_radiance,
      bool blend,
@@ -327,11 +327,11 @@ class Model {
  bool half_precision_;
  bool rgb_format_supported_;
  std::function<std::string(const vec3&)> glsl_header_factory_;
  unsigned int transmittance_texture_;
  unsigned int scattering_texture_;
  unsigned int optional_single_mie_scattering_texture_;
  unsigned int irradiance_texture_;
  unsigned int atmosphere_shader_;
  GLuint transmittance_texture_;
  GLuint scattering_texture_;
  GLuint optional_single_mie_scattering_texture_;
  GLuint irradiance_texture_;
  GLuint atmosphere_shader_;
  GLuint full_screen_quad_vao_;
  GLuint full_screen_quad_vbo_;
}; @@ -525,11 +525,11 @@ we must first initialize the GPU shader, which can be done with the following
    program_ = glCreateProgram();
    glAttachShader(program_, vertex_shader);
    glAttachShader(program_, fragment_shader);
    glAttachShader(program_, model_->GetShader());
    glAttachShader(program_, model_->shader());
    glLinkProgram(program_);
    glDetachShader(program_, vertex_shader);
    glDetachShader(program_, fragment_shader);
    glDetachShader(program_, model_->GetShader());
    glDetachShader(program_, model_->shader());
    glDeleteShader(vertex_shader);
    glDeleteShader(fragment_shader);
@@ -90,7 +90,8 @@ its structure and its documentation and give more details about its tests.
implementation</a> can be used in C++ / OpenGL applications as explained
in <a href="atmosphere/model.h.html">model.h</a>, and as demonstrated in the
demo in <code>atmosphere/demo</code>. To run this demo, simply type <code>make
demo</code> in the main directory.
demo</code> in the main directory. A WebGL2 version of this demo is also
available <a href="demo.html">online</a>.

<p>The default settings of this demo use the real solar spectrum, with an ozone
layer. To simulate the settings of the original implementation, set the solar
@@ -123,7 +124,8 @@ atmosphere model on GPU.
<ul>
  <li>The <code>atmosphere/demo</code> directory shows how the API provided in
     <code>atmosphere</code> can be used in practice, using a small C++/OpenGL
     demo application.
     demo application. A WebGL2 version of this demo is also available, in the
    <code>webgl</code> subdirectory.
  </li>
  <li>The <code>atmosphere/reference</code> directory provides a way to execute
    our GLSL code on CPU. Its main purpose is to provide unit tests for the GLSL
@@ -152,6 +154,12 @@ extensive comments in each source code file:
      <li><a href="atmosphere/demo/demo.cc.html">demo.cc</a></li>
      <li><a href="atmosphere/demo/demo.glsl.html">demo.glsl</a></li>
      <li><a href="atmosphere/demo/demo_main.cc.html">demo_main.cc</a></li>
      <li>webgl<ul>
        <li><a href="atmosphere/demo/webgl/demo.js.html">demo.js</a></li>
        <li>
          <a href="atmosphere/demo/webgl/precompute.cc.html">precompute.cc</a>
        </li>
      </ul></li>
    </ul></li>
    <li>reference<ul>
      <li><a href="atmosphere/reference/definitions.h.html"> @@ -55,6 +55,17 @@
					<Add option="-g" />
				</Compiler>
			</Target>
			<Target title="Webgl">
				<Option output="output/Webgl/precompute" prefix_auto="1" extension_auto="1" />
				<Option object_output="output/Webgl/" />
				<Option type="1" />
				<Option compiler="gcc" />
				<Compiler>
					<Add option="-fexpensive-optimizations" />
					<Add option="-O3" />
					<Add option="-DNDEBUG" />
				</Compiler>
			</Target>
		</Build>
		<Compiler>
			<Add option="-Wmain" />
@@ -76,46 +87,63 @@
		<Unit filename="atmosphere/constants.h">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/definitions.glsl">
			<Option compile="1" />
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/demo.cc">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/demo.glsl">
			<Option compile="1" />
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/demo.h">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/demo_main.cc">
			<Option target="Debug" />
			<Option target="Release" />
		</Unit>
		<Unit filename="atmosphere/demo/webgl/demo.html">
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/webgl/demo.js">
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/demo/webgl/precompute.cc">
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/functions.glsl">
			<Option compile="1" />
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Test" />
			<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/model.cc">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/model.h">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="atmosphere/reference/definitions.h">
			<Option target="Test" />
@@ -189,11 +217,13 @@
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="external/glad/src/glad.cc">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="IntegrationTest" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="external/minpng/minpng.h">
			<Option target="IntegrationTest" />
@@ -204,18 +234,23 @@
		<Unit filename="external/progress_bar/util/progress_bar.h">
			<Option target="IntegrationTest" />
		</Unit>
		<Unit filename="index" />
		<Unit filename="index">
			<Option target="Docgen" />
		</Unit>
		<Unit filename="text/font.inc">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="text/text_renderer.cc">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="text/text_renderer.h">
			<Option target="Debug" />
			<Option target="Release" />
			<Option target="Webgl" />
		</Unit>
		<Unit filename="tools/docgen_main.cc">
			<Option target="Docgen" />