### PR TITLE
Simplify installation with build dependencies links and emscripten version specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Features
 Build the javascript version
 ----------------------------
 
-You need to make sure you have both emscripten and sconstruct installed.
+You need to make sure you have both [emscripten](https://emscripten.org/docs/getting_started/downloads.html) and [sconstruct](https://pypi.org/project/SCons/) installed.
 
     # Setup emscripten path.
     source $PATH_TO_EMSDK/emsdk_env.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Features
 Build the javascript version
 ----------------------------
 
-You need to make sure you have both [emscripten](https://emscripten.org/docs/getting_started/downloads.html) and [sconstruct](https://pypi.org/project/SCons/) installed.
+You need to make sure you have both [emscripten](https://emscripten.org/docs/getting_started/downloads.html) 1.40.1 (it does not work with latest version) and [sconstruct](https://pypi.org/project/SCons/) installed.
 
     # Setup emscripten path.
     source $PATH_TO_EMSDK/emsdk_env.sh


### PR DESCRIPTION
Hello.

There are a lot of issue reports related to emscripten version: #88, #113, #74. Let's specify it in a build instruction?

Also, there are links added to speed up emscripten and scons setup.