### PR TITLE
Docker dev server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3
+#RUN apt-get update && \
+#    DEBIAN_FRONTEND=noninteractive apt-get install -q -y curl && \
+#    apt-get clean && \
+#    rm -rf /var/lib/apt/lists/*
+ENV EMSCRIPTEN_VERSION=2.0.34
+RUN pip3 install scons
+WORKDIR /emscripten
+RUN curl -L https://github.com/emscripten-core/emsdk/archive/refs/tags/${EMSCRIPTEN_VERSION}.tar.gz | tar --strip-components=1 -xvzf - && \
+    ./emsdk install ${EMSCRIPTEN_VERSION} && \
+    ./emsdk activate ${EMSCRIPTEN_VERSION}
+WORKDIR /build
+COPY . /build
+RUN cd /emscripten && . /emscripten/emsdk_env.sh && cd /build && make js
+
+FROM nginx:alpine
+COPY --from=0 /build/apps/ /usr/share/nginx/html/
+COPY --from=0 /build/build/ /usr/share/nginx/html/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
 FROM python:3
-#RUN apt-get update && \
-#    DEBIAN_FRONTEND=noninteractive apt-get install -q -y curl && \
-#    apt-get clean && \
-#    rm -rf /var/lib/apt/lists/*
 ENV EMSCRIPTEN_VERSION=2.0.34
 RUN pip3 install scons
 WORKDIR /emscripten

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ web engine for further development.
     # run the web engine in a web server
     docker run -it --rm -p 8080:80 webengine
 
-Once running, browse to http://localhost:8080 to open the web engine
+Once running, browse to http://localhost:8080/simple-html/stellarium-web-engine.html
+to open the web engine
 
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ You need to make sure you have both emscripten and sconstruct installed.
 
     # Now see apps/simple-html/ to try the library in a browser.
 
+Build the Docker version
+------------------------
+
+A `Dockerfile` is included that allows you to quickly build a functional
+web engine for further development.
+
+    # compile the current source code
+    docker build -t webengine .
+    
+    # run the web engine in a web server
+    docker run -it --rm -p 8080:80 webengine
+
+Once running, browse to http://localhost:8080 to open the web engine
+
 
 Contributing
 ------------

--- a/SConstruct
+++ b/SConstruct
@@ -15,9 +15,11 @@ VariantDir('build/ext_src', 'ext_src', duplicate=0)
 env = Environment(variables=vars)
 
 env.Append(CFLAGS= '-Wall -std=gnu11 -Wno-unknown-pragmas -D_GNU_SOURCE '
-                   '-Wno-missing-braces',
+                   '-Wno-missing-braces -Wno-unused-command-line-argument',
            CXXFLAGS='-Wall -std=gnu++11 -Wno-narrowing '
-                    '-Wno-unknown-pragmas -Wno-unused-function')
+                    '-Wno-unknown-pragmas -Wno-unused-function '
+                    '-Wno-unused-command-line-argument '
+                    '-Wno-unused-but-set-variable')
 
 if env['werror']:
     env.Append(CCFLAGS='-Werror')

--- a/apps/simple-html/stellarium-web-engine.html
+++ b/apps/simple-html/stellarium-web-engine.html
@@ -223,7 +223,7 @@
 
           // Force ui update when there is any change.
           stel.change(function(obj, attr) {
-            if (attr !== "hovered") {
+            if (attr !== "hovered")
               that.stel = Object.assign(Object.create(stel), {}, stel)
           })
 


### PR DESCRIPTION
Adds a `Dockerfile` that allows building the web engine without having to install extra software on the development machine.

The latest 2.x version of emscripten doesn't seem to work properly to build the source code without also modifying the build flags, so those changes are included as well.

There was also a syntax error in the simple-html that is corrected here.