### PR TITLE
Fixes link to XEphem reference manual

### DIFF
--- a/doc/cla/individual/dreamalligator.md
+++ b/doc/cla/individual/dreamalligator.md
@@ -1,0 +1,9 @@
+United States of America, 2025-01-23
+
+I hereby agree to the terms of the Stellarium Web Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Tom Spalding tom@blackforestbotanics.com https://github.com/dreamalligator

--- a/src/modules/comets.c
+++ b/src/modules/comets.c
@@ -325,7 +325,7 @@ static int comet_update(comet_t *comet, const observer_t *obs)
 
     // Compute vmag.
     // We use the g,k model: m = g + 5*log10(D) + 2.5*k*log10(r)
-    // (http://www.clearskyinstitute.com/xephem/help/xephem.html)
+    // (https://xephem.github.io/XEphem/Site/help/xephem.html)
     // XXX: probably better to switch to the same model as for asteroids.
     sr = vec3_norm(ph[0]);
     or = vec3_norm(comet->pvo[0]);


### PR DESCRIPTION
Changes `http://www.clearskyinstitute.com/xephem/help/xephem.html` to `https://xephem.github.io/XEphem/Site/help/xephem.html`.

Cheers, Tom